### PR TITLE
Add debug flag wrapper for client logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,13 @@ For optimal performance:
 9. Alt + W on Dashboard resets wallet configuration and redirects to Boot sequence
 10. If block event lines persist across sessions, use `window.clearBlockAnnotations()` in the browser console to clear them. Older annotations are automatically pruned.
 
+## Debug Logging
+
+Client-side logging can be noisy in production. All `console.log` calls are now
+wrapped with a simple debug flag. Set `localStorage.setItem('debugLogging', 'true')`
+in your browser to enable verbose logging. Remove the item or set it to `false`
+to silence debug output.
+
 ## License
 
 Available under the MIT License. This is an independent project not affiliated with Ocean.xyz.

--- a/static/js/logger.js
+++ b/static/js/logger.js
@@ -1,0 +1,12 @@
+(function() {
+    // Initialize DEBUG flag from localStorage or default to false
+    const stored = localStorage.getItem('debugLogging');
+    window.DEBUG = stored === 'true';
+
+    const originalLog = console.log.bind(console);
+    console.log = function(...args) {
+        if (window.DEBUG) {
+            originalLog(...args);
+        }
+    };
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,6 +33,9 @@
     <!-- Theme JS (added to ensure consistent application of theme) -->
     <script src="/static/js/theme.js"></script>
 
+    <!-- Logging wrapper -->
+    <script src="/static/js/logger.js"></script>
+
     <!-- Page-specific CSS -->
     {% block css %}{% endblock %}
 


### PR DESCRIPTION
## Summary
- add simple console.log wrapper controlled by `localStorage.debugLogging`
- include new script in base template
- document the logging flag in the README

## Testing
- `pytest -q` *(fails: command not found)*