### PR TITLE
Restrict batch request API

### DIFF
--- a/App.py
+++ b/App.py
@@ -802,6 +802,16 @@ def batch_requests():
                 method = item.get("method", "GET").upper()
                 params = item.get("params")
                 body = item.get("body")
+                allowed_methods = {"GET", "POST", "PUT", "DELETE"}
+                if (
+                    not path
+                    or not str(path).startswith("/api/")
+                    or str(path) == "/api/batch"
+                    or method not in allowed_methods
+                ):
+                    responses.append({"status": 400, "body": {"error": "invalid request"}})
+                    continue
+
                 resp = client.open(path, method=method, json=body, query_string=params)
                 try:
                     body_data = resp.get_json()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -230,3 +230,23 @@ def test_batch_endpoint(client):
     assert data["responses"][0]["body"]["wallet"] == "w"
     assert data["responses"][1]["status"] == 200
     assert "status" in data["responses"][1]["body"]
+
+
+def test_batch_invalid_path(client):
+    resp = client.post(
+        "/api/batch",
+        json={"requests": [{"method": "GET", "path": "/"}]},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["responses"][0]["status"] == 400
+
+
+def test_batch_invalid_method(client):
+    resp = client.post(
+        "/api/batch",
+        json={"requests": [{"method": "PATCH", "path": "/api/config"}]},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["responses"][0]["status"] == 400


### PR DESCRIPTION
## Summary
- prevent misuse of `/api/batch` by validating requested paths and HTTP methods
- add tests for invalid paths and methods

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`