### PR TITLE
Fix miner name detection with trailing digits

### DIFF
--- a/miner_specs.py
+++ b/miner_specs.py
@@ -93,8 +93,9 @@ def parse_worker_name(name: str) -> Optional[Dict[str, float]]:
         return None
     name_lower = name.lower()
     for pattern, specs in MODEL_SPECS:
-        boundary_pattern = rf"(?<![A-Za-z0-9]){pattern}(?![A-Za-z0-9])"
-        if re.search(boundary_pattern, name_lower):
+        strict_pattern = rf"(?<![A-Za-z0-9]){pattern}(?![A-Za-z0-9])"
+        relaxed_pattern = rf"(?<![A-Za-z]){pattern}(?![A-Za-z])"
+        if re.search(strict_pattern, name_lower) or re.search(relaxed_pattern, name_lower):
             power = specs.get("hashrate", 0) * specs.get("efficiency", 0)
             return {
                 "model": specs["model"],

--- a/tests/test_parse_worker_name.py
+++ b/tests/test_parse_worker_name.py
@@ -43,3 +43,9 @@ def test_parse_worker_name_generic_axe():
     assert specs["type"] == "Bitaxe"
     assert specs["efficiency"] == 15
     assert round(specs["power"]) == round(1.1 * 15)
+
+
+def test_parse_worker_name_allows_trailing_digits():
+    """Keywords should match even if the worker name ends with numbers."""
+    assert miner_specs.parse_worker_name("urlacher1")["model"] == "The Urlacher"
+    assert miner_specs.parse_worker_name("bitchimney1")["model"] == "BitChimney Heater"


### PR DESCRIPTION
## Summary
- broaden worker name pattern matching
- test trailing digits in worker names

## Testing
- `pytest -q`