### PR TITLE
Add comprehensive front-end tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,8 @@ jobs:
         node tests/js/formatDuration.test.js
         node tests/js/main_dom_safety.test.js
         node tests/js/normalizeHashrate.test.js
+        node tests/js/arrowIndicator.test.js
+        node tests/js/audioCrossfadeTheme.test.js
+        node tests/js/blockProbability.test.js
+        node tests/js/notificationsTimestamp.test.js
+        node tests/js/workerUtils.test.js

--- a/tests/js/arrowIndicator.test.js
+++ b/tests/js/arrowIndicator.test.js
@@ -1,0 +1,43 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { setupBasicDOM, setupJqueryStub } = require('./test_utils');
+
+setupBasicDOM();
+setupJqueryStub();
+
+// Provide theme and normalization stubs
+global.THEME = { SHARED: { GREEN: 'green', RED: 'red' } };
+global.getCurrentTheme = () => ({ SHARED: { GREEN: 'green', RED: 'red' } });
+global.window.normalizeHashrate = (v) => v;
+
+const filePath = path.join(__dirname, '../../static/js/main.js');
+const lines = fs.readFileSync(filePath, 'utf8').split('\n');
+const start = lines.findIndex(l => l.includes('class ArrowIndicator'));
+const end = lines.findIndex((l, i) => i > start && l.includes('// Create the singleton instance'));
+const snippet = lines.slice(start, end).join('\n');
+const augmented = `${snippet}\nglobalThis.ArrowIndicator = ArrowIndicator;`;
+
+const context = {
+    console,
+    window: global.window,
+    document: global.document,
+    localStorage: global.localStorage,
+    MutationObserver: global.MutationObserver,
+    setTimeout: global.setTimeout,
+    THEME,
+    getCurrentTheme
+};
+vm.createContext(context);
+vm.runInContext(augmented, context);
+context.arrowIndicator = new context.ArrowIndicator();
+
+context.arrowIndicator.updateIndicators({ pool_total_hashrate: 100, pool_total_hashrate_unit: 'th/s' });
+context.arrowIndicator.updateIndicators({ pool_total_hashrate: 200, pool_total_hashrate_unit: 'th/s' });
+assert.ok(context.arrowIndicator.arrowStates.pool_total_hashrate.includes('fa-angle-double-up'));
+
+context.arrowIndicator.updateIndicators({ pool_total_hashrate: 50, pool_total_hashrate_unit: 'th/s' });
+assert.ok(context.arrowIndicator.arrowStates.pool_total_hashrate.includes('fa-angle-double-down'));
+
+console.log('ArrowIndicator updateIndicators tests passed');

--- a/tests/js/audioCrossfadeTheme.test.js
+++ b/tests/js/audioCrossfadeTheme.test.js
@@ -1,0 +1,67 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { setupBasicDOM } = require('./test_utils');
+
+setupBasicDOM();
+
+// Stub Audio class used in the script
+class DummyAudio {
+    constructor() {
+        this.src = '';
+        this.volume = 1;
+        this.muted = false;
+        this.currentTime = 0;
+        this.duration = 10;
+        this.loop = false;
+    }
+    load() {}
+    play() { return { catch: () => {} }; }
+    pause() {}
+    addEventListener() {}
+    removeEventListener() {}
+}
+
+global.Audio = DummyAudio;
+
+// Provide required DOM elements
+const audioElement = new DummyAudio();
+const nextAudioElement = new DummyAudio();
+
+global.document.getElementById = (id) => {
+    switch (id) {
+        case 'backgroundAudio':
+            return audioElement;
+        case 'audioControl':
+            return { addEventListener: () => {} };
+        case 'audioIcon':
+            return { classList: { toggle: () => {}, add: () => {}, remove: () => {} } };
+        case 'volumeSlider':
+            return { addEventListener: () => {}, value: 100 };
+    }
+    return null;
+};
+
+// Speed up crossfade by running intervals immediately
+let intervalFn = null;
+global.setInterval = (fn) => { intervalFn = fn; return 1; };
+
+const filePath = path.join(__dirname, '../../static/js/audio.js');
+const code = fs.readFileSync(filePath, 'utf8');
+const context = { console, document: global.document, window: global.window, Audio: DummyAudio, setInterval: global.setInterval, clearInterval: () => {}, localStorage: global.localStorage };
+vm.createContext(context);
+vm.runInContext(code, context);
+
+assert.strictEqual(typeof context.window.crossfadeToTheme, 'function');
+
+context.window.crossfadeToTheme(true);
+for (let i = 0; i < 20; i++) { intervalFn(); }
+assert.strictEqual(audioElement.src, '/static/audio/ocean.mp3');
+
+context.window.crossfadeToTheme(false);
+for (let i = 0; i < 20; i++) { intervalFn(); }
+assert.strictEqual(audioElement.src, '/static/audio/bitcoin.mp3');
+
+assert.ok(intervalFn);
+console.log('audio crossfade theme tests passed');

--- a/tests/js/blockProbability.test.js
+++ b/tests/js/blockProbability.test.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { setupBasicDOM } = require('./test_utils');
+
+setupBasicDOM();
+
+const filePath = path.join(__dirname, '../../static/js/main.js');
+const lines = fs.readFileSync(filePath, 'utf8').split('\n');
+const start = lines.findIndex(l => l.includes('function calculateBlockProbability')); // start of snippet
+let end = start;
+while (end < lines.length && !lines[end].includes('function calculatePoolLuck')) { end++; }
+const snippet = lines.slice(start, end).join('\n');
+
+const context = { console, window: global.window };
+context.normalizeHashrate = (v) => v;
+context.numberWithCommas = (x) => Number(x).toLocaleString();
+vm.createContext(context);
+vm.runInContext(snippet, context);
+
+assert.strictEqual(context.calculateBlockProbability(100, 'th/s', 100), '1 : 1,000,000');
+assert.strictEqual(context.calculateBlockProbability(0, 'th/s', 100), 'N/A');
+assert.strictEqual(context.calculateBlockTime(100, 'th/s', 100), '19 years');
+assert.strictEqual(context.formatTimeRemaining(0), 'N/A');
+assert.strictEqual(context.formatTimeRemaining(600), '10 minutes');
+assert.strictEqual(context.formatTimeRemaining(3153600001), 'Never (statistically)');
+
+console.log('block probability and time calculation tests passed');

--- a/tests/js/notificationsTimestamp.test.js
+++ b/tests/js/notificationsTimestamp.test.js
@@ -1,0 +1,68 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { setupBasicDOM } = require('./test_utils');
+
+setupBasicDOM();
+
+const items = [
+    {
+        attributes: { 'data-timestamp': '2024-01-01T00:00:00Z' },
+        attr(name) { return this.attributes[name]; },
+        find(selector) {
+            if (selector === '.notification-time') {
+                return { text: t => { this.time = t; } };
+            }
+            if (selector === '.full-timestamp') {
+                return { text: t => { this.full = t; }, length: 1 };
+            }
+            return { length: 0, text: () => {} };
+        }
+    },
+    {
+        attributes: { 'data-timestamp': '2024-01-01T00:05:00Z' },
+        attr(name) { return this.attributes[name]; },
+        find(selector) {
+            if (selector === '.notification-time') {
+                return { text: t => { this.time = t; } };
+            }
+            if (selector === '.full-timestamp') {
+                return { text: t => { this.full = t; }, length: 1 };
+            }
+            return { length: 0, text: () => {} };
+        }
+    }
+];
+
+global.$ = (selector) => {
+    if (selector === '.notification-item') {
+        return { each: cb => items.forEach(item => cb.call(item)) };
+    }
+    if (typeof selector === 'object') {
+        return selector;
+    }
+    return { html: () => {}, show: () => {}, hide: () => {}, prop: () => {}, append: () => {} };
+};
+
+global.window.dashboardTimezone = 'UTC';
+
+const filePath = path.join(__dirname, '../../static/js/notifications.js');
+const lines = fs.readFileSync(filePath, 'utf8').split('\n');
+const start = lines.findIndex(l => l.includes('function updateNotificationTimestamps'));
+const end = lines.findIndex(l => l.includes('function showLoading'));
+const snippet = lines.slice(start, end).join('\n');
+
+const context = { console, window: global.window, $ };
+context.formatTimestamp = () => 'formatted';
+vm.createContext(context);
+vm.runInContext(snippet, context);
+
+context.updateNotificationTimestamps();
+
+assert.ok(typeof items[0].time === 'string');
+assert.ok(typeof items[0].full === 'string');
+assert.ok(typeof items[1].time === 'string');
+assert.ok(typeof items[1].full === 'string');
+
+console.log('notification timestamp update tests passed');

--- a/tests/js/test_utils.js
+++ b/tests/js/test_utils.js
@@ -1,0 +1,62 @@
+function setupBasicDOM() {
+    const storageStub = {
+        getItem: () => null,
+        setItem: () => {},
+        removeItem: () => {}
+    };
+
+    global.document = {
+        readyState: 'complete',
+        getElementById: () => null,
+        querySelectorAll: () => [],
+        querySelector: () => null,
+        addEventListener: (event, cb) => { if (event === 'DOMContentLoaded' && typeof cb === 'function') cb(); },
+        body: {}
+    };
+
+    global.window = {
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        localStorage: storageStub,
+        sessionStorage: storageStub,
+        navigator: {},
+        Chart: function () {}
+    };
+
+    global.localStorage = storageStub;
+    global.sessionStorage = storageStub;
+    global.MutationObserver = function () { this.observe = () => {}; };
+    global.setTimeout = (fn) => { if (typeof fn === 'function') fn(); return 0; };
+    global.setInterval = (fn) => { if (typeof fn === 'function') fn(); return 0; };
+    global.clearInterval = () => {};
+}
+
+function setupJqueryStub() {
+    global.$ = function () {
+        const obj = {};
+        obj.text = () => obj;
+        obj.attr = () => obj;
+        obj.remove = () => obj;
+        obj.after = () => obj;
+        obj.parent = () => ({ after: () => obj, append: () => obj });
+        obj.is = () => false;
+        obj.css = () => obj;
+        obj.append = () => obj;
+        obj.empty = () => obj;
+        obj.hide = () => obj;
+        obj.show = () => obj;
+        obj.on = () => obj;
+        obj.off = () => obj;
+        obj.keydown = () => obj;
+        obj.ready = () => obj;
+        obj.prop = () => obj;
+        obj.html = () => obj;
+        obj.appendTo = () => obj;
+        obj.each = () => obj;
+        obj.find = () => obj;
+        obj.length = 1;
+        return obj;
+    };
+}
+
+module.exports = { setupBasicDOM, setupJqueryStub };

--- a/tests/js/workerUtils.test.js
+++ b/tests/js/workerUtils.test.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { setupBasicDOM } = require('./test_utils');
+
+setupBasicDOM();
+
+const filePath = path.join(__dirname, '../../static/js/workers.js');
+const lines = fs.readFileSync(filePath, 'utf8').split('\n');
+const start = lines.findIndex(l => l.includes('function normalizeHashrate'));
+let end = lines.findIndex(l => l.includes('return Math.round(totalPower)'));
+if (end === -1) { end = lines.length; }
+const snippet = lines.slice(start, end + 2).join('\n');
+
+const context = { console, window: global.window, workerData: { power_cost: 0.1 } };
+vm.createContext(context);
+vm.runInContext(snippet, context);
+
+assert.strictEqual(context.normalizeHashrate(1, 'ph/s'), 1000);
+assert.strictEqual(context.normalizeHashrate(500, 'gh/s'), 0.5);
+assert.strictEqual(context.formatHashrateForDisplay(1500, 'th/s'), '1.50 PH/s');
+
+const worker = { status: 'online', power_consumption: 1000 };
+const cost = context.calculatePowerCost(worker);
+assert.ok(Math.abs(cost.dailyCost - 2.4) < 0.01);
+assert.ok(Math.abs(cost.monthlyCost - 72) < 0.1);
+
+console.log('worker utilities tests passed');


### PR DESCRIPTION
## Summary
- add reusable DOM setup helpers for JS tests
- test ArrowIndicator update behavior
- test audio theme crossfade logic
- test block probability and time helpers
- test notification timestamp updates
- test worker utilities for hashrate and power cost
- run new tests in CI

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`
- `node tests/js/formatCurrency.test.js && node tests/js/formatDuration.test.js && node tests/js/main_dom_safety.test.js && node tests/js/normalizeHashrate.test.js && node tests/js/arrowIndicator.test.js && node tests/js/audioCrossfadeTheme.test.js && node tests/js/blockProbability.test.js && node tests/js/notificationsTimestamp.test.js && node tests/js/workerUtils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_683cb0300ed08320bb247120934cf0a5