### PR TITLE
Fix memory leak in data service

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -11,11 +11,25 @@ from zoneinfo import ZoneInfo
 from concurrent.futures import ThreadPoolExecutor
 import requests
 from bs4 import BeautifulSoup
+from dataclasses import dataclass
 
 from models import OceanData, convert_to_ths
 from config import get_timezone
 from cache_utils import ttl_cache
 from miner_specs import parse_worker_name
+
+
+@dataclass
+class CachedResponse:
+    """Simplified response object storing only relevant fields."""
+
+    ok: bool
+    status_code: int
+    text: str
+
+    def json(self):
+        """Parse JSON from the stored text."""
+        return json.loads(self.text)
 
 
 class MiningDashboardService:
@@ -668,21 +682,24 @@ class MiningDashboardService:
 
     @ttl_cache(ttl_seconds=30, maxsize=20)
     def fetch_url(self, url: str, timeout: int = 5):
-        """
-        Fetch URL with error handling.
+        """Fetch URL content safely without leaking resources."""
 
-        Args:
-            url (str): URL to fetch
-            timeout (int): Timeout in seconds
-
-        Returns:
-            Response: Request response or None if failed
-        """
+        response = None
         try:
-            return self.session.get(url, timeout=timeout)
+            response = self.session.get(url, timeout=timeout)
+            text = response.text
+            status_code = response.status_code
+            ok = response.ok
+            return CachedResponse(ok=ok, status_code=status_code, text=text)
         except Exception as e:
             logging.error(f"Error fetching {url}: {e}")
             return None
+        finally:
+            if response is not None:
+                try:
+                    response.close()
+                except Exception:
+                    pass
 
     # Add the fetch_exchange_rates method after the fetch_url method
     def fetch_exchange_rates(self, base_currency="USD"):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -63,9 +63,21 @@ def test_generate_default_workers_data(monkeypatch):
 
 def test_fetch_url_success(monkeypatch):
     svc = MiningDashboardService(0, 0, "w")
-    resp = MagicMock()
-    monkeypatch.setattr(svc.session, "get", lambda url, timeout=5: resp)
-    assert svc.fetch_url("http://x") is resp
+
+    class DummyResp:
+        status_code = 200
+        ok = True
+        text = "{\"a\": 1}"
+
+        def json(self):
+            return {"a": 1}
+
+    monkeypatch.setattr(svc.session, "get", lambda url, timeout=5: DummyResp())
+
+    result = svc.fetch_url("http://x")
+    assert result.ok
+    assert result.status_code == 200
+    assert result.json() == {"a": 1}
 
 
 def test_fetch_url_error(monkeypatch):


### PR DESCRIPTION
## Summary
- avoid caching live `requests.Response` objects by introducing `CachedResponse`
- ensure `fetch_url` closes connections before returning simplified data
- adjust unit tests for new `fetch_url` return type

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_683e8d515de4832084ef3b2b0eff9a22