### PR TITLE
Fix payout scrape memory leak

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -857,7 +857,9 @@ class MiningDashboardService:
                 if not resp.ok:
                     if page == 0:
                         logging.error(f"Error fetching payout page: {resp.status_code}")
+                        resp.close()
                         return None
+                    resp.close()
                     break
 
                 soup = BeautifulSoup(resp.text, "html.parser")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -351,6 +351,27 @@ def test_get_payment_history_scrape_pagination(monkeypatch):
     assert payments[1]["txid"] == "tx2"
 
 
+def test_get_payment_history_scrape_closes_on_error(monkeypatch):
+    """Ensure HTTP response is closed when initial request fails."""
+    svc = MiningDashboardService(0, 0, "w")
+
+    class DummyResp:
+        def __init__(self):
+            self.ok = False
+            self.closed = False
+            self.status_code = 500
+
+        def close(self):
+            self.closed = True
+
+    dummy_resp = DummyResp()
+
+    monkeypatch.setattr(svc.session, "get", lambda url, headers=None, timeout=10: dummy_resp)
+
+    assert svc.get_payment_history_scrape() is None
+    assert dummy_resp.closed
+
+
 def test_get_earnings_data_fallback_to_scrape(monkeypatch):
     svc = MiningDashboardService(0, 0, "w")
 


### PR DESCRIPTION
## Summary
- close HTTP response in `get_payment_history_scrape` when request fails
- add regression test ensuring response is closed on error

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_683ef5f3cdd0832093bc6fc20b7667ac