### PR TITLE
Fix uninitialized response variable

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -733,6 +733,7 @@ class MiningDashboardService:
             logging.error("Exchange rate API key not configured")
             return {}
 
+        response = None
         try:
             # Use the configured API key with the v6 exchangerate-api endpoint
             url = f"https://v6.exchangerate-api.com/v6/{api_key}/latest/{base_currency}"


### PR DESCRIPTION
## Summary
- initialize `response` before the `try` block in `fetch_exchange_rates`

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683efbaead288320af4ca5cd5b89646e