### PR TITLE
Fix logging handler leak on reload

### DIFF
--- a/App.py
+++ b/App.py
@@ -123,6 +123,12 @@ file_handler.setFormatter(formatter)
 console_handler = logging.StreamHandler()
 console_handler.setFormatter(formatter)
 
+# Close any existing handlers before replacing them to avoid leaks
+for handler in list(logger.handlers):
+    try:
+        handler.close()
+    except Exception:
+        pass
 logger.handlers.clear()
 logger.addHandler(file_handler)
 logger.addHandler(console_handler)

--- a/tests/test_logging_handler_cleanup.py
+++ b/tests/test_logging_handler_cleanup.py
@@ -1,0 +1,28 @@
+import importlib
+import logging
+
+
+def test_reload_closes_previous_log_handlers(monkeypatch):
+    closed = []
+
+    class DummyHandler(logging.Handler):
+        def __init__(self):
+            super().__init__()
+            self.closed = False
+
+        def emit(self, record):
+            pass
+
+        def close(self):
+            self.closed = True
+            closed.append(self)
+
+    monkeypatch.setattr(logging.handlers, "RotatingFileHandler", lambda *a, **k: DummyHandler())
+    monkeypatch.setattr(logging, "StreamHandler", lambda *a, **k: DummyHandler())
+
+    App = importlib.reload(importlib.import_module("App"))
+    initial_handlers = list(logging.getLogger().handlers)
+
+    App = importlib.reload(App)
+
+    assert all(h.closed for h in initial_handlers)


### PR DESCRIPTION
## Summary
- close existing log handlers before replacing them in `App.py`
- add regression test ensuring handlers are closed on module reload

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684042fd66ac8320809cf7b24ebaf0bf