### PR TITLE
Fix matrix rain memory leak

### DIFF
--- a/static/js/matrixRain.js
+++ b/static/js/matrixRain.js
@@ -1,9 +1,12 @@
 (function() {
     "use strict";
 
+    let matrixIntervalId = null;
+    let resizeHandler = null;
+
     function initMatrixRain() {
         if (document.getElementById('matrixRain')) {
-            return; // avoid duplicate canvases
+            cleanupMatrixRain();
         }
 
         const canvas = document.createElement('canvas');
@@ -41,8 +44,24 @@
         }
 
         resize();
-        window.addEventListener('resize', resize);
-        setInterval(draw, 50);
+        resizeHandler = resize;
+        window.addEventListener('resize', resizeHandler);
+        matrixIntervalId = setInterval(draw, 50);
+    }
+
+    function cleanupMatrixRain() {
+        const canvas = document.getElementById('matrixRain');
+        if (canvas) {
+            canvas.remove();
+        }
+        if (resizeHandler) {
+            window.removeEventListener('resize', resizeHandler);
+            resizeHandler = null;
+        }
+        if (matrixIntervalId) {
+            clearInterval(matrixIntervalId);
+            matrixIntervalId = null;
+        }
     }
 
     document.addEventListener('DOMContentLoaded', function() {
@@ -52,4 +71,5 @@
     });
 
     window.initMatrixRain = initMatrixRain;
+    window.cleanupMatrixRain = cleanupMatrixRain;
 })();

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -160,6 +160,10 @@ function applyDeepSeaTheme() {
     try {
         console.log("Applying DeepSea theme...");
 
+        if (window.cleanupMatrixRain) {
+            window.cleanupMatrixRain();
+        }
+
         // Update the data-text attribute for DeepSea theme
         updateDashboardDataText(true);
 
@@ -514,6 +518,9 @@ function toggleTheme() {
 
     // Disable secret Matrix theme when toggling
     localStorage.setItem('useMatrixTheme', 'false');
+    if (window.cleanupMatrixRain) {
+        window.cleanupMatrixRain();
+    }
 
     // Update the data-text attribute based on the new theme
     updateDashboardDataText(useDeepSea);


### PR DESCRIPTION
## Summary
- add cleanupMatrixRain and manage interval to avoid leaks
- call cleanupMatrixRain when switching away from matrix theme
- regenerate minified assets

## Testing
- `make minify`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409a835e80832090a9a946a5be78a4