### PR TITLE
Fix memory leak when reloading dashboard service

### DIFF
--- a/App.py
+++ b/App.py
@@ -102,6 +102,7 @@ scheduler_recreate_lock = threading.Lock()
 
 # Track scheduler health
 _previous_scheduler = globals().get("scheduler")
+_previous_dashboard_service = globals().get("dashboard_service")
 scheduler = None
 
 # Global start time
@@ -1787,6 +1788,15 @@ if hasattr(dashboard_service, "set_worker_service"):
     dashboard_service.set_worker_service(worker_service)
 worker_service.set_dashboard_service(dashboard_service)
 notification_service.dashboard_service = dashboard_service
+
+# Close any previous dashboard service instance to avoid resource leaks
+if _previous_dashboard_service:
+    try:
+        _previous_dashboard_service.close()
+    except Exception as e:
+        logging.error(f"Error closing previous dashboard service: {e}")
+    finally:
+        _previous_dashboard_service = None
 
 # Restore critical state if available
 last_run, last_update = state_manager.load_critical_state()

--- a/tests/test_service_reload_cleanup.py
+++ b/tests/test_service_reload_cleanup.py
@@ -1,0 +1,23 @@
+import importlib
+
+
+def test_previous_dashboard_service_closed(monkeypatch):
+    App = importlib.reload(importlib.import_module("App"))
+
+    class DummyService:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    dummy = DummyService()
+    App.dashboard_service = dummy
+
+    monkeypatch.setattr("data_service.MiningDashboardService", lambda *a, **k: DummyService())
+
+    App = importlib.reload(App)
+
+    assert dummy.closed
+    assert App._previous_dashboard_service is None
+


### PR DESCRIPTION
## Summary
- ensure previous dashboard service is closed on reload
- add regression test

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411b30beec83208f95dd34080f76d8