### PR TITLE
Fix flip-card height calculation

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -2060,8 +2060,9 @@ function initializeFlippableCards() {
     document.querySelectorAll('.flip-card').forEach(card => {
         const front = card.querySelector('.card-front');
         const back = card.querySelector('.card-back');
-        const frontHeight = front ? front.offsetHeight : 0;
-        const backHeight = back ? back.offsetHeight : 0;
+        // Use scrollHeight to account for collapsed absolute elements
+        const frontHeight = front ? front.scrollHeight : 0;
+        const backHeight = back ? back.scrollHeight : 0;
         const cardHeight = Math.max(frontHeight, backHeight);
         if (cardHeight) {
             card.style.height = `${cardHeight}px`;


### PR DESCRIPTION
## Summary
- ensure flip cards use `scrollHeight` so collapsed elements can size themselves
- regenerate minified assets

## Testing
- `pip install -r requirements.txt`
- `make minify`
- `PYTHONPATH=$PWD pytest`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_6841a95136b083208b19048820920f52