### PR TITLE
Update block probability wording

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -930,7 +930,7 @@ function formatTimeRemaining(seconds) {
 
     // Extremely large values (over 100 years) are not useful
     if (seconds > 3153600000) { // 100 years in seconds
-        return "Never (statistically)";
+        return "Never";
     }
 
     const minutes = seconds / 60;

--- a/tests/js/blockProbability.test.js
+++ b/tests/js/blockProbability.test.js
@@ -24,6 +24,6 @@ assert.strictEqual(context.calculateBlockProbability(0, 'th/s', 100), 'N/A');
 assert.strictEqual(context.calculateBlockTime(100, 'th/s', 100), '19 years');
 assert.strictEqual(context.formatTimeRemaining(0), 'N/A');
 assert.strictEqual(context.formatTimeRemaining(600), '10 minutes');
-assert.strictEqual(context.formatTimeRemaining(3153600001), 'Never (statistically)');
+assert.strictEqual(context.formatTimeRemaining(3153600001), 'Never');
 
 console.log('block probability and time calculation tests passed');


### PR DESCRIPTION
## Summary
- tweak `formatTimeRemaining` wording for very large values
- update JS test expectation

## Testing
- `ruff check .`
- `PYTHONPATH=$PWD pytest -q`
- `node tests/js/blockProbability.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68433d04e574832080ea6e56d8d2627e