### PR TITLE
Remove sparklines from earnings metrics

### DIFF
--- a/static/js/sparklines.js
+++ b/static/js/sparklines.js
@@ -30,7 +30,22 @@
             'unpaid_earnings',
             'pool_fees_percentage',
             'last_block',
-            'est_time_to_payout'
+            'est_time_to_payout',
+            'daily_mined_sats',
+            'monthly_mined_sats',
+            'estimated_earnings_per_day_sats',
+            'estimated_earnings_next_block_sats',
+            'estimated_rewards_in_window_sats',
+            'daily_revenue',
+            'daily_power_cost',
+            'daily_profit_usd',
+            'monthly_profit_usd',
+            'difficulty',
+            'block_number',
+            'hashrate_24hr',
+            'hashrate_3hr',
+            'hashrate_10min',
+            'hashrate_60sec'
         ]);
 
         document.querySelectorAll('[id^="indicator_"]').forEach(indicator => {

--- a/tests/test_sparklines_skip_keys.py
+++ b/tests/test_sparklines_skip_keys.py
@@ -9,5 +9,25 @@ def test_sparklines_skip_keys():
     match = re.search(r"skipKeys = new Set\((\[[^\]]*\])\)", content)
     assert match, 'skipKeys set not found'
     keys = ast.literal_eval(match.group(1))
-    for key in ['pool_fees_percentage', 'last_block', 'est_time_to_payout']:
+    required = [
+        'pool_fees_percentage',
+        'last_block',
+        'est_time_to_payout',
+        'daily_mined_sats',
+        'monthly_mined_sats',
+        'estimated_earnings_per_day_sats',
+        'estimated_earnings_next_block_sats',
+        'estimated_rewards_in_window_sats',
+        'daily_revenue',
+        'daily_power_cost',
+        'daily_profit_usd',
+        'monthly_profit_usd',
+        'difficulty',
+        'block_number',
+        'hashrate_24hr',
+        'hashrate_3hr',
+        'hashrate_10min',
+        'hashrate_60sec',
+    ]
+    for key in required:
         assert key in keys


### PR DESCRIPTION
## Summary
- skip sparkline charts for earnings metrics and several hashrate/network stats
- update tests for new skip list

## Testing
- `make minify`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843a3eab480832080f3f07d5bc6c59e