### PR TITLE
Add Canaan home miner specs

### DIFF
--- a/docs/WORKER-NAMING.md
+++ b/docs/WORKER-NAMING.md
@@ -20,7 +20,7 @@ To ensure your miners are detected correctly, include one of the keywords below 
 |--------------|----------------------------|
 | **Bitmain Antminer** | `s9`, `s17 pro`, `t19`, `s19`, `s19 pro`, `s19j`, `s19j pro`, `s19j pro+`, `s19 pro++`, `s19k pro`, `s19 xp`, `s19 xp hyd`, `s19 pro+ hyd`, `t21`, `s21`, `s21 hydro`, `s21 pro`, `s21+`, `s21+ hydro`, `s21 xp hydro` |
 | **MicroBT Whatsminer** | `m20s`, `m30s`, `m30s+`, `m30s++`, `m31s`, `m31s+`, `m50`, `m50s`, `m50s++`, `m53`, `m56`, `m60s`, `m66s` |
-| **Canaan AvalonMiner** | `1166`, `1246`, `1346`, `1366`, `1466`, `1466i`, `1566` |
+| **Canaan AvalonMiner** | `1166`, `1246`, `1346`, `1366`, `1466`, `1466i`, `1566`, `avalon q`, `avalon mini 3`, `avalon nano 3s`, `avalon nano 3` |
 | **Other / DIY** | `sealminer a2`, `t3+`, `e11++`, `apollo`, `apollo btc ii`, `compac`, `bitaxe`, `nerdaxe`, `bitchimney`, `loki`, `urlacher`, `slim`, `heatbit` |
 
 The table lists only the identifying portion that needs to appear anywhere in the name. For instance, both `rig-s19pro-01` and `S19 Pro Worker` will match `s19 pro`.

--- a/miner_specs.py
+++ b/miner_specs.py
@@ -61,6 +61,11 @@ MODEL_SPECS = [
         {"model": "Canaan AvalonMiner 1566 Immersion", "type": "ASIC", "hashrate": 195, "efficiency": 19},
     ),
     (r"1566", {"model": "Canaan AvalonMiner 1566", "type": "ASIC", "hashrate": 185, "efficiency": 19.9}),
+    # Canaan home series
+    (r"avalon[-_\s]*q", {"model": "Canaan Avalon Q", "type": "ASIC", "hashrate": 90, "efficiency": 18.6}),
+    (r"avalon[-_\s]*mini[-_\s]*3", {"model": "Canaan Avalon Mini 3", "type": "ASIC", "hashrate": 37.5, "efficiency": 21.3}),
+    (r"avalon[-_\s]*nano[-_\s]*3s", {"model": "Canaan Avalon Nano 3S", "type": "ASIC", "hashrate": 6, "efficiency": 23.3}),
+    (r"avalon[-_\s]*nano[-_\s]*3", {"model": "Canaan Avalon Nano 3", "type": "ASIC", "hashrate": 4, "efficiency": 35}),
     # Other ASICs and DIY devices
     (r"sealminer[-_\s]*a2", {"model": "Sealminer A2", "type": "ASIC", "hashrate": 260, "efficiency": 16.5}),
     (r"t3\+", {"model": "Innosilicon T3+", "type": "ASIC", "hashrate": 52, "efficiency": 53.8}),

--- a/static/js/workers.js
+++ b/static/js/workers.js
@@ -103,6 +103,10 @@ const ASIC_EFFICIENCY_DATA = {
     "Canaan Avalon A1346": { efficiency: 0.035, defaultWatts: 3276 },
     "Canaan Avalon A1466I": { efficiency: 0.051, defaultWatts: 3315 },
     "Canaan Avalon A1466": { efficiency: 0.047, defaultWatts: 3225 },
+    "Canaan Avalon Q": { efficiency: 0.0186, defaultWatts: 1674 },
+    "Canaan Avalon Mini 3": { efficiency: 0.0213, defaultWatts: 800 },
+    "Canaan Avalon Nano 3S": { efficiency: 0.0233, defaultWatts: 140 },
+    "Canaan Avalon Nano 3": { efficiency: 0.035, defaultWatts: 140 },
 
     // BitAxe and DIY Mining Devices (much smaller scale)
     "BitAxe": { efficiency: 0.005, defaultWatts: 35 },

--- a/tests/test_parse_worker_name.py
+++ b/tests/test_parse_worker_name.py
@@ -65,3 +65,21 @@ def test_parse_worker_name_separator_variations():
         miner_specs.parse_worker_name("apollo-btc_ii")["model"]
         == "FutureBit Apollo BTC II"
     )
+
+
+def test_parse_worker_name_canaan_home_models():
+    specs = miner_specs.parse_worker_name("my-avalon_q")
+    assert specs["model"] == "Canaan Avalon Q"
+    assert specs["type"] == "ASIC"
+    assert round(specs["power"]) == round(90 * 18.6)
+
+    specs = miner_specs.parse_worker_name("avalon-mini3")
+    assert specs["model"] == "Canaan Avalon Mini 3"
+
+    specs = miner_specs.parse_worker_name("avalon-nano3s_home")
+    assert specs["model"] == "Canaan Avalon Nano 3S"
+
+    specs = miner_specs.parse_worker_name("Avalon_Nano3")
+    assert specs["model"] == "Canaan Avalon Nano 3"
+
+


### PR DESCRIPTION
## Summary
- document Canaan's home miners in worker naming guide
- include Avalon Q, Mini 3, Nano 3S and Nano 3 in miner specs
- expose the new models on the frontend worker table
- test parse_worker_name for new Canaan models

## Testing
- `make minify`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843bf78b7a883209e913dd5ecbe0736