### PR TITLE
Add exchange rate API key option

### DIFF
--- a/App.py
+++ b/App.py
@@ -1018,6 +1018,7 @@ def update_config():
             "power_cost": 0.0,
             "power_usage": 0.0,
             "currency": "USD",  # Add default currency
+            "EXCHANGE_RATE_API_KEY": ""
         }
 
         # Merge new config with defaults for any missing fields

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -19,6 +19,7 @@ The default configuration file contains the following keys:
 | `timezone` | Local timezone identifier | `"America/Los_Angeles"` |
 | `network_fee` | Additional fees beyond pool fees | `0.0` |
 | `currency` | Preferred fiat currency for earnings display | `"USD"` |
+| `EXCHANGE_RATE_API_KEY` | ExchangeRate-API key for currency conversion | `""` |
 | `low_hashrate_threshold_ths` | Threshold used by the notification service to determine low hashrate mode (TH/s). Does **not** affect the front-end chart. | `3.0` |
 | `high_hashrate_threshold_ths` | Threshold above which normal hashrate mode resumes (TH/s) | `20.0` |
 
@@ -36,6 +37,7 @@ cause the application to fall back to default values and log an error.
 | `NETWORK_FEE` | Additional fees beyond pool fees | from `config.json` |
 | `TIMEZONE` | Local timezone identifier | from `config.json` |
 | `CURRENCY` | Preferred fiat currency | from `config.json` |
+| `EXCHANGE_RATE_API_KEY` | ExchangeRate-API key for currency rates | from `config.json` |
 | `FLASK_ENV` | Application environment | `development` |
 | `LOG_LEVEL` | Logging level | `INFO` |
 | `PORT` | Application port | `5000` |

--- a/templates/boot.html
+++ b/templates/boot.html
@@ -695,6 +695,16 @@
             </select>
         </div>
         <div class="form-group">
+            <label for="exchange-rate-api-key">
+                Exchange Rate API Key
+                <span class="tooltip">
+                    ?
+                    <span class="tooltip-text">Optional key for fiat conversions</span>
+                </span>
+            </label>
+            <input type="text" id="exchange-rate-api-key" placeholder="Optional" value="">
+        </div>
+        <div class="form-group">
             <label for="power-cost">
                 Power Cost ($/kWh)
                 <span class="tooltip">
@@ -882,6 +892,7 @@
             const timezone = document.getElementById('timezone').value;
             const networkFee = parseFloat(document.getElementById('network-fee').value) || 0;
             const currency = document.getElementById('currency').value;
+            const apiKey = document.getElementById('exchange-rate-api-key').value.trim();
 
             const updatedConfig = {
                 wallet: wallet || (currentConfig ? currentConfig.wallet : ""),
@@ -889,7 +900,8 @@
                 power_usage: powerUsage,
                 timezone: timezone,
                 network_fee: networkFee,
-                currency: currency
+                currency: currency,
+                EXCHANGE_RATE_API_KEY: apiKey
             };
 
             return fetch('/api/config', {
@@ -959,6 +971,7 @@
                         document.getElementById('power-cost').value = currentConfig.power_cost || "";
                         document.getElementById('power-usage').value = currentConfig.power_usage || "";
                         document.getElementById('network-fee').value = currentConfig.network_fee || "";
+                        document.getElementById('exchange-rate-api-key').value = currentConfig.EXCHANGE_RATE_API_KEY || "";
 
                         // Set currency dropdown value if available
                         if (currentConfig.currency) {
@@ -976,13 +989,15 @@
                             power_cost: 0.0,
                             power_usage: 0.0,
                             network_fee: 0.0,
-                            currency: "USD"
+                            currency: "USD",
+                            EXCHANGE_RATE_API_KEY: ""
                         };
 
                         document.getElementById('wallet-address').value = currentConfig.wallet || "";
                         document.getElementById('power-cost').value = currentConfig.power_cost || "";
                         document.getElementById('power-usage').value = currentConfig.power_usage || "";
                         document.getElementById('network-fee').value = currentConfig.network_fee || "";
+                        document.getElementById('exchange-rate-api-key').value = currentConfig.EXCHANGE_RATE_API_KEY || "";
                         document.getElementById('currency').value = currentConfig.currency || "USD";
 
                         resolve(currentConfig);
@@ -1030,6 +1045,7 @@
             document.getElementById('power-cost').value = 0.0;
             document.getElementById('power-usage').value = 0.0;
             document.getElementById('network-fee').value = 0.0;
+            document.getElementById('exchange-rate-api-key').value = '';
 
             // Visual feedback
             const btn = document.getElementById('use-defaults');

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -57,6 +57,23 @@ def test_update_config_endpoint(client):
     assert data["status"] == "success"
 
 
+def test_update_config_with_api_key(client, monkeypatch):
+    import App
+    saved = {}
+
+    def capture(cfg):
+        saved.update(cfg)
+        return True
+
+    monkeypatch.setattr(App, "save_config", capture)
+    resp = client.post(
+        "/api/config",
+        json={"wallet": "abc", "EXCHANGE_RATE_API_KEY": "KEY"},
+    )
+    assert resp.status_code == 200
+    assert saved.get("EXCHANGE_RATE_API_KEY") == "KEY"
+
+
 def test_payout_history_endpoint(client):
     resp = client.get("/api/payout-history")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- support saving ExchangeRate-API key through boot configurator
- send key with /api/config updates
- document `EXCHANGE_RATE_API_KEY` in configuration docs
- test update_config includes key

## Testing
- `make minify`
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684734fb86188320b6b309dcb2b54415