### PR TITLE
Fix Matrix theme toggle color

### DIFF
--- a/static/css/matrix.css
+++ b/static/css/matrix.css
@@ -9,6 +9,7 @@ html.matrix-theme #themeToggle,
 html.matrix-theme .theme-toggle-btn {
   color: #39ff14;
   border-color: #39ff14;
+  background-color: #000;
 }
 
 html.matrix-theme #themeToggle:hover,


### PR DESCRIPTION
## Summary
- match Matrix theme toggle background to main background

## Testing
- `make minify-css`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684787d58d5c8320a545f569fdb4db45