### PR TITLE
Modify matrix rain rotation

### DIFF
--- a/static/js/matrixRain.js
+++ b/static/js/matrixRain.js
@@ -72,7 +72,8 @@
                 ctx.font = fonts[Math.floor(Math.random() * fonts.length)];
                 ctx.save();
                 ctx.translate(i * 20, drop.y * 20);
-                const angle = (Math.random() - 0.5) * (Math.PI / 3);
+                // Only rotate 30% of characters for a subtle effect
+                const angle = Math.random() < 0.3 ? (Math.random() - 0.5) * (Math.PI / 3) : 0;
                 ctx.rotate(angle);
                 ctx.fillText(char, 0, 0);
                 ctx.restore();


### PR DESCRIPTION
## Summary
- rotate only 30% of characters in the matrix rain animation

## Testing
- `PYTHONPATH=$PWD pytest`
- `make minify-js`


------
https://chatgpt.com/codex/tasks/task_e_68486aec12b08320800da2da0fa00691