### PR TITLE
Improve payout history UX

### DIFF
--- a/static/css/common.css
+++ b/static/css/common.css
@@ -776,6 +776,23 @@ html.deepsea-theme h1::after {
   box-shadow: 0 0 5px rgba(var(--primary-color-rgb), 0.8);
 }
 
+/* Generic loading text */
+.loading-message {
+    text-align: center;
+    padding: 20px;
+    color: #888;
+}
+
+/* Simple spinner used during async actions */
+.loading-spinner {
+    border: 4px solid rgba(255, 255, 255, 0.2);
+    border-top: 4px solid var(--primary-color);
+    border-radius: 50%;
+    width: 30px;
+    height: 30px;
+    animation: spin 1s linear infinite;
+}
+
 /* Status dots */
 .online-dot {
   display: inline-block;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -850,6 +850,14 @@ function showLoadingOverlay(elementId) {
     }, 2000);
 }
 
+// Display a loading message in the payout history container
+function showPayoutLoading() {
+    const container = $('#payout-history-container');
+    container.html(
+        "<div class='loading-message'>Loading payout summary<span class='terminal-cursor'></span></div>"
+    );
+}
+
 // Helper function to format hashrate values for display
 function formatHashrateForDisplay(value, unit) {
     if (isNaN(value) || value === null || value === undefined) return "N/A";
@@ -1335,15 +1343,15 @@ function togglePayoutHistoryDisplay() {
         container.slideUp();
         button.text("VIEW LAST PAYOUT");
     } else {
-        // Clear the container first
-        container.empty();
-
-        // Refresh history from earnings API then display summary
-        refreshPayoutHistoryFromEarnings(displayPayoutSummary);
+        // Show loading message while fetching data
+        showPayoutLoading();
 
         // Show the container and update button text
         container.slideDown();
         button.text("HIDE LAST PAYOUT");
+
+        // Refresh history from earnings API then display summary
+        refreshPayoutHistoryFromEarnings(displayPayoutSummary);
     }
 }
 


### PR DESCRIPTION
## Summary
- add generic loading styles
- show loading indicator when fetching payout summary

## Testing
- `make minify`
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_684f95c81aa48320883d7d271bc8d820