### PR TITLE
Fix memory leak in StateManager

### DIFF
--- a/state_manager.py
+++ b/state_manager.py
@@ -66,7 +66,7 @@ class StateManager:
         self.load_last_earnings()
 
     def close(self):
-        """Close Redis connection and release resources."""
+        """Close Redis connection and clear cached data."""
         if self.redis_client:
             try:
                 self.redis_client.close()
@@ -74,6 +74,26 @@ class StateManager:
                 logging.error(f"Error closing Redis connection: {e}")
             finally:
                 self.redis_client = None
+
+        # Clear in-memory history structures to free memory
+        self.arrow_history.clear()
+        self.hashrate_history.clear()
+        self.metrics_log.clear()
+        self.payout_history.clear()
+        self.variance_history.clear()
+        self.last_earnings.clear()
+
+        # Clear caches of ttl_cache decorated methods
+        for func in (
+            self.load_graph_state,
+            self.load_payout_history,
+            self.load_last_earnings,
+        ):
+            if hasattr(func, "cache_clear"):
+                try:
+                    func.cache_clear()
+                except Exception:
+                    pass
 
     def __del__(self):
         """Ensure Redis connection is closed on garbage collection."""

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -304,3 +304,26 @@ def test_close_closes_redis_connection():
     assert dummy.closed
     assert mgr.redis_client is None
 
+
+def test_close_clears_cached_data():
+    from datetime import datetime
+
+    mgr = StateManager()
+    mgr.arrow_history = {"k": deque([{"time": "00:00:00", "value": 1}])}
+    mgr.hashrate_history.append(1)
+    mgr.metrics_log.append({"timestamp": "t", "metrics": {"a": 1}})
+    mgr.payout_history = [1]
+    mgr.variance_history = {"v": deque([{"time": datetime.now(), "value": 1}])}
+    mgr.last_earnings = {"v": 1}
+
+    mgr.close()
+
+    assert mgr.arrow_history == {}
+    assert len(mgr.hashrate_history) == 0
+    assert len(mgr.metrics_log) == 0
+    assert mgr.payout_history == []
+    assert mgr.variance_history == {}
+    assert mgr.last_earnings == {}
+    assert mgr.load_graph_state.cache_size() == 0
+    assert mgr.load_payout_history.cache_size() == 0
+    assert mgr.load_last_earnings.cache_size() == 0


### PR DESCRIPTION
## Summary
- clear history structures and caches in `StateManager.close`
- test that `StateManager.close` frees memory and cached data

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685081d5b4d0832084a6bcbc16796301