### PR TITLE
Improve audio controller

### DIFF
--- a/static/js/BitcoinProgressBar.js
+++ b/static/js/BitcoinProgressBar.js
@@ -32,7 +32,8 @@ const BitcoinMinuteRefresh = (function () {
         AUDIO_PREV: 'audio-prev',
         AUDIO_PLAY: 'audio-play',
         AUDIO_NEXT: 'audio-next',
-        AUDIO_PROGRESS: 'audio-progress'
+        AUDIO_PROGRESS: 'audio-progress',
+        AUDIO_REMAINING: 'audio-remaining'
     };
     // Add these new keys to the STORAGE_KEYS constant
     const STORAGE_KEYS = {
@@ -988,6 +989,7 @@ const BitcoinMinuteRefresh = (function () {
                 <span id="${DOM_IDS.AUDIO_NEXT}" class="audio-btn">&#9654;&#9654;</span>
               </div>
               <input id="${DOM_IDS.AUDIO_PROGRESS}" class="audio-progress" type="range" min="0" max="100" value="0">
+              <div id="${DOM_IDS.AUDIO_REMAINING}" class="audio-remaining">-0:00</div>
             </div>
           </div>
           <div class="page-controls">
@@ -1377,6 +1379,12 @@ const BitcoinMinuteRefresh = (function () {
 
       .audio-progress {
         width: 100%;
+      }
+
+      .audio-remaining {
+        text-align: center;
+        font-size: 12px;
+        margin-top: 2px;
       }
 
       .memory-gauge {

--- a/static/js/audio.js
+++ b/static/js/audio.js
@@ -11,6 +11,7 @@
         const prevBtn = document.getElementById('audioPrev');
         const nextBtn = document.getElementById('audioNext');
         const progressBar = document.getElementById('audioProgress');
+        const timeDisplay = document.getElementById('audioRemaining');
         if (!audio) { return; }
         const crossfadeDuration = 2;
         let isCrossfading = false;
@@ -80,6 +81,7 @@
                 }
                 audio.removeEventListener('loadedmetadata', resume);
                 updateProgress();
+                updatePlayButton();
             };
 
             if (audio.readyState > 0) {
@@ -87,6 +89,13 @@
             } else {
                 audio.addEventListener('loadedmetadata', resume);
             }
+        };
+
+        const formatTime = (seconds) => {
+            if (Number.isNaN(seconds)) return '0:00';
+            const m = Math.floor(seconds / 60);
+            const s = Math.floor(seconds % 60).toString().padStart(2, '0');
+            return `${m}:${s}`;
         };
 
         const crossfadeToIndex = (index) => {
@@ -121,6 +130,7 @@
                     audio.addEventListener('ended', onTrackEnded);
                     storedTime = 0;
                     updateProgress();
+                    updatePlayButton();
                     isCrossfading = false;
                 }
             }, interval);
@@ -172,6 +182,7 @@
                     audio.addEventListener('ended', onTrackEnded);
                     storedTime = 0;
                     updateProgress();
+                    updatePlayButton();
                     isCrossfading = false;
                 }
             }, interval);
@@ -190,6 +201,12 @@
             }
         };
 
+        const updatePlayButton = () => {
+            if (playBtn) {
+                playBtn.textContent = audio.paused ? '\u25BA' : '\u275A\u275A';
+            }
+        };
+
         const togglePlay = () => {
             if (audio.paused) {
                 audio.muted = false;
@@ -202,6 +219,7 @@
                 audio.pause();
             }
             localStorage.setItem('audioPaused', audio.paused.toString());
+            updatePlayButton();
         };
 
         const seekTo = (pct) => {
@@ -229,6 +247,10 @@
         function updateProgress() {
             if (progressBar && audio.duration) {
                 progressBar.value = (audio.currentTime / audio.duration) * 100;
+            }
+            if (timeDisplay && audio.duration) {
+                const remaining = Math.max(0, audio.duration - audio.currentTime);
+                timeDisplay.textContent = '-' + formatTime(remaining);
             }
         }
 

--- a/tests/test_audio_controller.py
+++ b/tests/test_audio_controller.py
@@ -8,6 +8,7 @@ def test_audio_controller_ids_present():
     assert "audio-prev" in content
     assert "audio-next" in content
     assert "audio-play" in content
+    assert "audio-remaining" in content
 
 
 def test_audio_controller_functions():


### PR DESCRIPTION
## Summary
- show remaining time for current track
- swap play/pause icon based on state
- expose new DOM ID for time display in audio widget
- test for additional element

## Testing
- `make minify-js`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68508dc73b2883208016a2b3fc9c9f1d