### PR TITLE
Remember system monitor page

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ For more details, refer to the [docker-compose documentation](https://docs.docke
 - System uptime display
 - Real-time connection status
 - Optional audio controls with progress bar
+- Remembers the last monitor page you viewed, including audio controls
 
 ## System Requirements
 

--- a/static/js/BitcoinProgressBar.js
+++ b/static/js/BitcoinProgressBar.js
@@ -46,7 +46,8 @@ const BitcoinMinuteRefresh = (function () {
         POSITION_TOP: 'bitcoin_terminal_top',
         SNAP_POINT: 'bitcoin_terminal_snap_point',
         COLLAPSED_SNAP_POINT: 'bitcoin_terminal_collapsed_snap_point',
-        HIDDEN: 'bitcoin_terminal_hidden'
+        HIDDEN: 'bitcoin_terminal_hidden',
+        LAST_PAGE: 'bitcoin_monitor_last_page'
     };
     const SELECTORS = {
         HEADER: '.terminal-header',
@@ -1669,6 +1670,11 @@ const BitcoinMinuteRefresh = (function () {
         pages.forEach((p, i) => {
             p.style.display = i === currentPage ? 'block' : 'none';
         });
+        try {
+            localStorage.setItem(STORAGE_KEYS.LAST_PAGE, currentPage.toString());
+        } catch (e) {
+            log('Failed to store current page: ' + e.message, 'error');
+        }
     }
 
     function nextPage() { showPage(currentPage + 1); }
@@ -1795,7 +1801,14 @@ const BitcoinMinuteRefresh = (function () {
         if (audioPlay) audioPlay.addEventListener('click', () => window.togglePlay && window.togglePlay());
         if (audioProgress) audioProgress.addEventListener('input', (e) => window.seekAudio && window.seekAudio(parseFloat(e.target.value)));
 
-        showPage(0);
+        let savedPage = 0;
+        try {
+            const stored = parseInt(localStorage.getItem(STORAGE_KEYS.LAST_PAGE) || '0');
+            if (!isNaN(stored)) savedPage = stored;
+        } catch (e) {
+            log('Failed to read last page: ' + e.message, 'error');
+        }
+        showPage(savedPage);
         fetchHealth();
         if (healthInterval) clearInterval(healthInterval);
         healthInterval = setInterval(fetchHealth, 10000);

--- a/tests/test_audio_controller.py
+++ b/tests/test_audio_controller.py
@@ -9,6 +9,14 @@ def test_audio_controller_ids_present():
     assert "audio-next" in content
     assert "audio-play" in content
     assert "audio-remaining" in content
+    assert "bitcoin_monitor_last_page" in content
+
+
+def test_audio_controller_persistence():
+    js_path = Path("static/js/BitcoinProgressBar.js")
+    content = js_path.read_text()
+    assert "STORAGE_KEYS.LAST_PAGE" in content
+    assert "localStorage.setItem" in content
 
 
 def test_audio_controller_functions():


### PR DESCRIPTION
## Summary
- persist system monitor page in `BitcoinProgressBar.js`
- update README docs about monitor persistence
- test for audio controller page persistence

## Testing
- `make minify`
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509228e3f88320b115d013ebb07686