### PR TITLE
Fix notification service cleanup

### DIFF
--- a/notification_service.py
+++ b/notification_service.py
@@ -159,6 +159,21 @@ class NotificationService:
         # Load last block height from state
         self._load_last_block_height()
 
+    def close(self):
+        """Release references and clear cached data."""
+        try:
+            self.notifications.clear()
+            self.dashboard_service = None
+            self.state_manager = None
+        except Exception:
+            pass
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
     @property
     def dashboard_service(self):
         """Return the dashboard service if it is still alive."""

--- a/tests/test_notification_service.py
+++ b/tests/test_notification_service.py
@@ -226,6 +226,16 @@ class RedisValueTest(unittest.TestCase):
         result = svc._get_redis_value("val", "default")
         self.assertEqual(result, "1")
 
+    def test_close_clears_state(self):
+        svc = NotificationService(DummyStateManager())
+        svc.notifications = [{"id": "1"}]
+        svc.dashboard_service = object()
+        svc.close()
+
+        self.assertEqual(svc.notifications, [])
+        self.assertIsNone(svc.dashboard_service)
+        self.assertIsNone(svc.state_manager)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- clear notifications and references in `NotificationService.close`
- handle previous notification service on reload
- close notification service during shutdown
- test cleanup behavior

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685099c05060832098e7391ada5b6742