### PR TITLE
Improve system monitor audio progress bar styling

### DIFF
--- a/static/js/BitcoinProgressBar.js
+++ b/static/js/BitcoinProgressBar.js
@@ -1391,6 +1391,31 @@ const BitcoinMinuteRefresh = (function () {
 
       .audio-progress {
         width: 100%;
+        height: 6px;
+        margin-top: 4px;
+        appearance: none;
+        background-color: rgba(var(--primary-color-rgb, ${theme.rgb}), 0.2);
+        border: 1px solid rgba(var(--primary-color-rgb, ${theme.rgb}), 0.5);
+        border-radius: 2px;
+        background-image: linear-gradient(
+          to right,
+          var(--primary-color, ${theme.color}) var(--audio-progress-value, 0%),
+          rgba(var(--primary-color-rgb, ${theme.rgb}), 0.2) var(--audio-progress-value, 0%)
+        );
+        background-repeat: no-repeat;
+        cursor: pointer;
+      }
+
+      .audio-progress::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        width: 0;
+        height: 0;
+      }
+
+      .audio-progress::-moz-range-thumb {
+        width: 0;
+        height: 0;
+        border: none;
       }
 
       .audio-remaining {

--- a/static/js/audio.js
+++ b/static/js/audio.js
@@ -13,6 +13,14 @@
         let progressBar = document.getElementById('audio-progress');
         let timeDisplay = document.getElementById('audio-remaining');
         let showRemaining = true;
+        let rootStyle = null;
+        let primaryColor = '';
+        let primaryRgb = '';
+        if (typeof getComputedStyle === 'function') {
+            rootStyle = getComputedStyle(document.documentElement);
+            primaryColor = rootStyle.getPropertyValue('--primary-color').trim();
+            primaryRgb = rootStyle.getPropertyValue('--primary-color-rgb').trim();
+        }
         if (!audio) { return; }
         const crossfadeDuration = 2;
         let isCrossfading = false;
@@ -258,7 +266,11 @@
                 timeDisplay = document.getElementById('audio-remaining');
             }
             if (progressBar && audio.duration) {
-                progressBar.value = (audio.currentTime / audio.duration) * 100;
+                const pct = (audio.currentTime / audio.duration) * 100;
+                progressBar.value = pct;
+                progressBar.style.setProperty('--audio-progress-value', pct + '%');
+                progressBar.style.background =
+                    `linear-gradient(to right, ${primaryColor} ${pct}%, rgba(${primaryRgb}, 0.2) ${pct}%)`;
             }
             if (timeDisplay && audio.duration) {
                 if (showRemaining) {


### PR DESCRIPTION
## Summary
- style the audio progress bar to match site themes
- update progress bar background on playback progress
- gracefully handle missing `getComputedStyle` when loading audio theme colors
- rebuild minified assets

## Testing
- `pip install -r requirements.txt`
- `make minify`
- `PYTHONPATH=$PWD pytest -q`
- Front-end tests via Node:
  - `node tests/js/formatCurrency.test.js`
  - `node tests/js/formatDuration.test.js`
  - `node tests/js/main_dom_safety.test.js`
  - `node tests/js/main_chart_load.test.js`
  - `node tests/js/normalizeHashrate.test.js`
  - `node tests/js/arrowIndicator.test.js`
  - `node tests/js/audioCrossfadeTheme.test.js`
  - `node tests/js/getBlockTimerClass.test.js`
  - `node tests/js/blockProbability.test.js`
  - `node tests/js/notificationsTimestamp.test.js`
  - `node tests/js/workerUtils.test.js`
  - `node tests/js/themeToggle.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6850e0aba8dc83209dd80eb4573ecf92