### PR TITLE
Refactor notification routes into blueprint

### DIFF
--- a/App.py
+++ b/App.py
@@ -51,6 +51,7 @@ from memory_manager import (
 )
 
 import sse_service
+import notification_routes
 
 # Initialize Flask app
 app = Flask(__name__)
@@ -135,6 +136,8 @@ if _previous_notification_service:
         logging.error(f"Error closing previous notification service: {e}")
     finally:
         _previous_notification_service = None
+notification_routes.init_notification_routes(notification_service)
+app.register_blueprint(notification_routes.notifications_bp)
 
 # Initialize memory manager with required dependencies
 init_memory_manager(
@@ -996,85 +999,6 @@ def force_gc():
         return jsonify({"status": "error", "message": "internal server error"}), 500
 
 
-@app.route("/api/notifications")
-def api_notifications():
-    """API endpoint for notification data."""
-    limit = request.args.get("limit", 50, type=int)
-    offset = request.args.get("offset", 0, type=int)
-    unread_only = request.args.get("unread_only", "false").lower() == "true"
-    category = request.args.get("category")
-    level = request.args.get("level")
-
-    notifications = notification_service.get_notifications(
-        limit=limit, offset=offset, unread_only=unread_only, category=category, level=level
-    )
-
-    unread_count = notification_service.get_unread_count()
-
-    return jsonify(
-        {
-            "notifications": notifications,
-            "unread_count": unread_count,
-            "total": len(notifications),
-            "limit": limit,
-            "offset": offset,
-        }
-    )
-
-
-@app.route("/api/notifications/unread_count")
-def api_unread_count():
-    """API endpoint for unread notification count."""
-    return jsonify({"unread_count": notification_service.get_unread_count()})
-
-
-@app.route("/api/notifications/mark_read", methods=["POST"])
-def api_mark_read():
-    """API endpoint to mark notifications as read."""
-    notification_id = request.json.get("notification_id")
-
-    success = notification_service.mark_as_read(notification_id)
-
-    return jsonify({"success": success, "unread_count": notification_service.get_unread_count()})
-
-
-@app.route("/api/notifications/delete", methods=["POST"])
-def api_delete_notification():
-    """API endpoint to delete a notification."""
-    notification_id = request.json.get("notification_id")
-
-    if not notification_id:
-        return jsonify({"error": "notification_id is required"}), 400
-
-    success = notification_service.delete_notification(notification_id)
-
-    return jsonify({"success": success, "unread_count": notification_service.get_unread_count()})
-
-
-@app.route("/api/notifications/clear", methods=["POST"])
-def api_clear_notifications():
-    """API endpoint to clear notifications."""
-    category = request.json.get("category")
-    older_than_days = request.json.get("older_than_days")
-    read_only = request.json.get("read_only", False)  # Get the read_only parameter with default False
-
-    cleared_count = notification_service.clear_notifications(
-        category=category,
-        older_than_days=older_than_days,
-        read_only=read_only,  # Pass the parameter to the method
-    )
-
-    return jsonify(
-        {"success": True, "cleared_count": cleared_count, "unread_count": notification_service.get_unread_count()}
-    )
-
-
-# Add notifications page route
-@app.route("/notifications")
-def notifications_page():
-    """Serve the notifications page."""
-    current_time = datetime.now(ZoneInfo(get_timezone())).strftime("%b %d, %Y, %I:%M:%S %p")
-    return render_template("notifications.html", current_time=current_time)
 
 
 # Service worker route

--- a/notification_routes.py
+++ b/notification_routes.py
@@ -1,0 +1,104 @@
+"""Blueprint for notification-related routes."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+from typing import Any
+from flask import Blueprint, jsonify, render_template, request
+
+from config import get_timezone
+
+notifications_bp = Blueprint("notifications", __name__)
+
+_notification_service = None
+
+
+def init_notification_routes(service: Any) -> None:
+    """Store the notification service used by the routes."""
+    global _notification_service
+    _notification_service = service
+
+
+@notifications_bp.route("/api/notifications")
+def api_notifications():
+    """Return notification data."""
+    limit = request.args.get("limit", 50, type=int)
+    offset = request.args.get("offset", 0, type=int)
+    unread_only = request.args.get("unread_only", "false").lower() == "true"
+    category = request.args.get("category")
+    level = request.args.get("level")
+
+    notifications = _notification_service.get_notifications(
+        limit=limit,
+        offset=offset,
+        unread_only=unread_only,
+        category=category,
+        level=level,
+    )
+
+    unread_count = _notification_service.get_unread_count()
+
+    return jsonify(
+        {
+            "notifications": notifications,
+            "unread_count": unread_count,
+            "total": len(notifications),
+            "limit": limit,
+            "offset": offset,
+        }
+    )
+
+
+@notifications_bp.route("/api/notifications/unread_count")
+def api_unread_count():
+    """Return unread notification count."""
+    return jsonify({"unread_count": _notification_service.get_unread_count()})
+
+
+@notifications_bp.route("/api/notifications/mark_read", methods=["POST"])
+def api_mark_read():
+    """Mark a notification as read."""
+    notification_id = request.json.get("notification_id")
+    success = _notification_service.mark_as_read(notification_id)
+    return jsonify({"success": success, "unread_count": _notification_service.get_unread_count()})
+
+
+@notifications_bp.route("/api/notifications/delete", methods=["POST"])
+def api_delete_notification():
+    """Delete a notification."""
+    notification_id = request.json.get("notification_id")
+    if not notification_id:
+        return jsonify({"error": "notification_id is required"}), 400
+    success = _notification_service.delete_notification(notification_id)
+    return jsonify({"success": success, "unread_count": _notification_service.get_unread_count()})
+
+
+@notifications_bp.route("/api/notifications/clear", methods=["POST"])
+def api_clear_notifications():
+    """Clear notifications based on filters."""
+    category = request.json.get("category")
+    older_than_days = request.json.get("older_than_days")
+    read_only = request.json.get("read_only", False)
+
+    cleared_count = _notification_service.clear_notifications(
+        category=category,
+        older_than_days=older_than_days,
+        read_only=read_only,
+    )
+
+    return jsonify(
+        {
+            "success": True,
+            "cleared_count": cleared_count,
+            "unread_count": _notification_service.get_unread_count(),
+        }
+    )
+
+
+@notifications_bp.route("/notifications")
+def notifications_page():
+    """Render the notifications page."""
+    current_time = datetime.now(ZoneInfo(get_timezone())).strftime("%b %d, %Y, %I:%M:%S %p")
+    return render_template("notifications.html", current_time=current_time)
+


### PR DESCRIPTION
## Summary
- create `notification_routes` blueprint
- register the new blueprint in `App.py`
- drop the old notification route definitions from `App.py`

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`
- `ruff .`

------
https://chatgpt.com/codex/tasks/task_e_6854b129972c8320ac009b05cbd2155e