### PR TITLE
Refactor memory endpoints into blueprint

### DIFF
--- a/memory_routes.py
+++ b/memory_routes.py
@@ -1,0 +1,132 @@
+"""Blueprint for memory management endpoints."""
+
+from __future__ import annotations
+
+import gc
+import logging
+import os
+import sys
+import time
+from collections import deque
+from typing import Any
+
+import psutil
+from flask import Blueprint, jsonify, request
+
+from memory_manager import (
+    memory_usage_history,
+    memory_usage_lock,
+    log_memory_usage,
+    state_manager,
+)
+import sse_service
+
+memory_bp = Blueprint("memory", __name__)
+
+
+@memory_bp.route("/api/memory-profile")
+def memory_profile() -> Any:
+    """Return a detailed memory profile."""
+    try:
+        process = psutil.Process(os.getpid())
+        mem_info = process.memory_info()
+
+        type_counts: dict[str, int] = {}
+        for obj in gc.get_objects():
+            obj_type = type(obj).__name__
+            type_counts[obj_type] = type_counts.get(obj_type, 0) + 1
+        most_common = sorted(type_counts.items(), key=lambda x: x[1], reverse=True)[:15]
+
+        memory_trend: dict[str, Any] = {}
+        if memory_usage_history:
+            recent = memory_usage_history[-1]
+            oldest = memory_usage_history[0] if len(memory_usage_history) > 1 else recent
+            memory_trend = {
+                "oldest_timestamp": oldest.get("timestamp"),
+                "recent_timestamp": recent.get("timestamp"),
+                "growth_mb": recent.get("rss_mb", 0) - oldest.get("rss_mb", 0),
+                "growth_percent": recent.get("percent", 0) - oldest.get("percent", 0),
+            }
+
+        uptime_seconds = time.time() - process.create_time()
+        return jsonify(
+            {
+                "memory": {
+                    "rss_mb": mem_info.rss / 1024 / 1024,
+                    "vms_mb": mem_info.vms / 1024 / 1024,
+                    "percent": process.memory_percent(),
+                    "data_structures": {
+                        "arrow_history": {
+                            "entries": sum(
+                                len(v)
+                                for v in state_manager.get_history().values()
+                                if isinstance(v, (list, deque))
+                            ),
+                            "keys": list(state_manager.get_history().keys()),
+                        },
+                        "metrics_log": {"entries": len(state_manager.get_metrics_log())},
+                        "memory_usage_history": {"entries": len(memory_usage_history)},
+                        "sse_connections": sse_service.active_sse_connections,
+                    },
+                    "most_common_objects": dict(most_common),
+                    "trend": memory_trend,
+                },
+                "gc": {
+                    "garbage": len(gc.garbage),
+                    "counts": gc.get_count(),
+                    "threshold": gc.get_threshold(),
+                    "enabled": gc.isenabled(),
+                },
+                "system": {
+                    "uptime_seconds": uptime_seconds,
+                    "python_version": sys.version,
+                },
+            }
+        )
+    except Exception as e:  # pragma: no cover - defensive
+        logging.error(f"Error in memory profiling: {e}")
+        return jsonify({"error": "internal server error"}), 500
+
+
+@memory_bp.route("/api/memory-history")
+def memory_history() -> Any:
+    """Return historical memory usage metrics."""
+    with memory_usage_lock:
+        history_copy = list(memory_usage_history)
+    process = psutil.Process(os.getpid())
+    return jsonify(
+        {
+            "history": history_copy,
+            "current": {
+                "rss_mb": process.memory_info().rss / 1024 / 1024,
+                "percent": process.memory_percent(),
+            },
+        }
+    )
+
+
+@memory_bp.route("/api/force-gc", methods=["POST"])
+def force_gc() -> Any:
+    """Run garbage collection and report statistics."""
+    try:
+        generation = request.json.get("generation", 2) if request.is_json else 2
+        if generation not in [0, 1, 2]:
+            generation = 2
+        start_time = time.time()
+        objects_before = len(gc.get_objects())
+        collected = gc.collect(generation)
+        duration = time.time() - start_time
+        objects_after = len(gc.get_objects())
+        log_memory_usage()
+        return jsonify(
+            {
+                "status": "success",
+                "collected": collected,
+                "duration_seconds": duration,
+                "objects_removed": objects_before - objects_after,
+                "generation": generation,
+            }
+        )
+    except Exception as e:  # pragma: no cover - defensive
+        logging.error(f"Error during forced GC: {e}")
+        return jsonify({"status": "error", "message": "internal server error"}), 500

--- a/tests/test_memory_routes.py
+++ b/tests/test_memory_routes.py
@@ -1,0 +1,99 @@
+import importlib
+import sys
+import types
+from collections import deque
+
+if "pytest" not in sys.modules:
+    pytest = types.ModuleType("pytest")
+
+    def fixture(func=None, **kwargs):
+        if func is None:
+            return lambda f: f
+        return func
+
+    pytest.fixture = fixture
+    sys.modules["pytest"] = pytest
+else:
+    import pytest
+
+
+@pytest.fixture
+def client(monkeypatch):
+    import apscheduler.schedulers.background as bg
+
+    monkeypatch.setattr(bg.BackgroundScheduler, "start", lambda self: None)
+    importlib.reload(importlib.import_module("sse_service"))
+    App = importlib.reload(importlib.import_module("App"))
+
+    monkeypatch.setattr(App, "update_metrics_job", lambda force=False: None)
+    monkeypatch.setattr(App, "MiningDashboardService", lambda *a, **k: object())
+    monkeypatch.setattr(App.worker_service, "set_dashboard_service", lambda *a, **k: None)
+
+    sample_cfg = {"wallet": "w"}
+    import config as cfg
+    import config_routes
+    monkeypatch.setattr(cfg, "load_config", lambda: sample_cfg)
+    monkeypatch.setattr(cfg, "save_config", lambda c: True)
+    monkeypatch.setattr(config_routes, "load_config", lambda: sample_cfg)
+    monkeypatch.setattr(config_routes, "save_config", lambda c: True)
+
+    return App.app.test_client()
+
+
+def test_memory_history_endpoint(client, monkeypatch):
+    import memory_routes
+    import memory_manager
+
+    history = deque([{"timestamp": "t1", "rss_mb": 1, "percent": 1}], maxlen=10)
+    monkeypatch.setattr(memory_manager, "memory_usage_history", history)
+    monkeypatch.setattr(memory_routes, "memory_usage_history", history)
+
+    class DummyLock:
+        def __enter__(self):
+            pass
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(memory_routes, "memory_usage_lock", DummyLock())
+
+    class DummyProc:
+        def __init__(self, _):
+            pass
+
+        def memory_info(self):
+            return types.SimpleNamespace(rss=1024, vms=2048)
+
+        def memory_percent(self):
+            return 2.0
+
+    monkeypatch.setattr(memory_routes.psutil, "Process", DummyProc)
+
+    resp = client.get("/api/memory-history")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["history"] == list(history)
+    assert data["current"]["percent"] == 2.0
+
+
+def test_force_gc_endpoint(client, monkeypatch):
+    import memory_routes
+
+    sequence = {"flag": True}
+
+    def fake_get_objects():
+        if sequence["flag"]:
+            sequence["flag"] = False
+            return [1, 2, 3]
+        return [1]
+
+    monkeypatch.setattr(memory_routes.gc, "get_objects", fake_get_objects)
+    monkeypatch.setattr(memory_routes.gc, "collect", lambda g: 2)
+    monkeypatch.setattr(memory_routes, "log_memory_usage", lambda: None)
+
+    resp = client.post("/api/force-gc", json={"generation": 1})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["generation"] == 1
+    assert data["objects_removed"] == 2
+


### PR DESCRIPTION
## Summary
- extract memory-related API routes into a new `memory_routes` blueprint
- register the blueprint in the main app
- cover blueprint with new tests

## Testing
- `ruff .`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854bb0a75bc8320bc41e8680fc7fd73