### PR TITLE
Add CSV download for hashrate data

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -824,3 +824,24 @@ html.bitcoin-theme #btc_price:hover {
     width: 40px !important;
   }
 }
+
+.hashrate-actions {
+  margin-top: 0.5rem;
+  text-align: right;
+}
+
+.download-btn {
+  display: inline-block;
+  padding: 4px 8px;
+  font-family: var(--terminal-font);
+  font-size: 0.9rem;
+  color: var(--primary-color);
+  border: 1px solid var(--primary-color);
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.download-btn:hover {
+  background-color: var(--primary-color);
+  color: var(--bg-color);
+}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -218,6 +218,11 @@
                     </span>
                     <span id="indicator_hashrate_60sec"></span>
                 </p>
+                <div class="hashrate-actions text-end">
+                    <a href="/api/history?format=csv" class="download-btn" download>
+                        <i class="fa-solid fa-download"></i> Download CSV
+                    </a>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add a download button in Pool Hashrates card
- style the new button
- minify updated assets

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e067eadb4832080e4605faf46a3f5