### PR TITLE
Ensure block annotations persist in extended history

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -519,7 +519,7 @@ function loadBlockAnnotations(minutes = 180, maxEntries = 100) {
                         console.error('Error processing block event', err);
                     }
                 });
-                saveBlockAnnotations();
+                saveBlockAnnotations(minutes);
                 if (trendChart) {
                     updateBlockAnnotations(trendChart);
                     trendChart.update('none');
@@ -2122,7 +2122,7 @@ function checkForBlockUpdates(data) {
         if (trendChart && trendChart.data && trendChart.data.labels.length > 0) {
             const ts = new Date().toISOString();
             blockAnnotations.push(ts);
-            saveBlockAnnotations();
+            saveBlockAnnotations(chartPoints);
             updateBlockAnnotations(trendChart);
         }
     }


### PR DESCRIPTION
## Summary
- preserve block annotation history for extended history mode by passing current chart duration to `saveBlockAnnotations`
- regenerate minified assets

## Testing
- `make minify`
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ef736d9a0832084d8b81e684e65fc