### PR TITLE
Add release template with packaging notes for Start9/Umbrel

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,0 +1,19 @@
+## ✨ v{VERSION} – {TITLE}
+
+**Full Changelog**: https://github.com/Djobleezy/DeepSea-Dashboard/compare/v{PREV}...v{VERSION}
+
+### 🆕 What's New
+- 
+
+### 🐛 Bug Fixes
+- 
+
+### 🔐 Security
+- 
+
+### 📦 Packaging Notes (Start9 / Umbrel)
+- **Breaking:** None — drop-in update
+- **Config:** No schema changes
+- **Ports:** Still 8000 (unchanged)
+- **Env vars:** None added/removed
+- **Docker:** No entrypoint changes

--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -17,3 +17,17 @@
 - **Ports:** Still 8000 (unchanged)
 - **Env vars:** None added/removed
 - **Docker:** No entrypoint changes
+
+---
+
+### Usage
+
+GitHub auto-generates changelogs from PR labels via `.github/release.yml`.
+This template adds the **Packaging Notes** section for downstream packagers (Start9, Umbrel).
+
+```bash
+# Create a release using this template as a starting point:
+gh release create v2.x.x --generate-notes --notes-file .github/RELEASE_TEMPLATE.md --draft
+```
+
+Edit the draft on GitHub to fill in version-specific details before publishing.

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  categories:
+    - title: "🆕 What's New"
+      labels:
+        - enhancement
+        - feature
+    - title: "🐛 Bug Fixes"
+      labels:
+        - bug
+        - fix
+    - title: "🔐 Security"
+      labels:
+        - security
+    - title: "📦 Packaging"
+      labels:
+        - packaging
+        - docker
+    - title: "🧹 Maintenance"
+      labels:
+        - chore
+        - dependencies


### PR DESCRIPTION
### What

Adds `.github/RELEASE_TEMPLATE.md` — a pre-filled template for GitHub releases.

### Why

DeepSea is now [packaged for Start9](https://github.com/Retropex/DeepSea-startos/releases/tag/v2.0.4) by downstream maintainers. A consistent **Packaging Notes** section in each release helps them know instantly whether a new version is a drop-in update or requires wrapper changes (config schema, ports, env vars, Docker entrypoint).

### What it looks like

Every new release starts pre-filled with:
- **What's New / Bug Fixes / Security** — standard sections
- **Packaging Notes (Start9 / Umbrel)** — breaking changes, config, ports, env vars, Docker

Fill in the blanks, delete sections that don't apply, publish.