### PR TITLE
fix(datum): add live gateway probe — fix lagging-fee false OFFLINE badge

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -90,6 +90,34 @@ anything other than `"USD"`. Leave empty if you only need USD display.
 
 ---
 
+### `datum_gateway_url`
+- **Type:** `string` (URL)
+- **Default:** `""` (disabled)
+- **Examples:**
+  - UmbrelOS (DATUM app installed): `"http://datum_datum_1:21000"`
+  - Stock self-build on the same host: `"http://127.0.0.1:7152"`
+  - Bare metal on the LAN: `"http://192.168.1.50:21000"`
+- **Environment override:** `DATUM_GATEWAY_URL`
+
+Optional URL of a local [DATUM Gateway](https://github.com/OCEAN-xyz/datum_gateway). When set,
+the dashboard probes the gateway directly (via its `/umbrel-api` JSON endpoint and a TCP
+stratum-port check as a fallback) to render a **real-time** DATUM connection badge.
+
+**Why this matters:** the default DATUM badge is derived from `pool_fees_percentage`, which is
+an *average* of historical work as reported on Ocean's stats page. After a user enables DATUM
+that average can take **hours or days** to land inside the 0.9%–1.3% "DATUM range" — during
+that window the badge would show OFFLINE even though the gateway is fully operational. Setting
+`datum_gateway_url` gives the dashboard a current-state signal so it can show a clearly
+labelled "DATUM ACTIVE (fees settling)" badge during that transition window.
+
+The environment variable `DATUM_GATEWAY_URL` overrides this field at request time, which is
+useful for Docker / Umbrel compose setups where you'd rather wire the URL via the service
+rather than the JSON file.
+
+Probe traffic is small (one ~2 s HTTP `GET` cached for 15 s) and never leaves your network.
+
+---
+
 ### `low_hashrate_threshold_ths`
 - **Type:** `float` (TH/s)
 - **Default:** `3.0`
@@ -121,6 +149,7 @@ match the upper end of your expected operating range.
   "network_fee": 2.0,
   "extended_history": false,
   "exchange_rate_api_key": "",
+  "datum_gateway_url": "",
   "low_hashrate_threshold_ths": 3.0,
   "high_hashrate_threshold_ths": 20.0
 }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Real-time Bitcoin mining dashboard for [Ocean.xyz](https://ocean.xyz) pool miner
 - **3 Themes** — DeepSea (blue), Bitcoin (orange), Matrix (green) with CRT scanlines and phosphor glow
 - **Audio Player** — Theme-aware playlists with crossfade transitions
 - **PWA Support** — Service worker, offline caching, cross-tab sync via BroadcastChannel
-- **DATUM Gateway** — Connection status indicator for Ocean's DATUM protocol
+- **DATUM Gateway** — Real-time connection status indicator for Ocean's DATUM protocol, with optional direct gateway probe to avoid the lagging `pool_fees_percentage` signal
 - **Batch API** — Dashboard loads metrics + workers + blocks in a single HTTP call
 - **Mobile First** — Hamburger nav, responsive grid, touch-optimized
 
@@ -352,6 +352,37 @@ Each [GitHub Release](https://github.com/Djobleezy/DeepSea-Dashboard/releases) i
 - **Wallet not configured** — edit `config.json` and set `wallet` to your Ocean.xyz payout address
 - **Ocean.xyz API unreachable** — check your network; the backend logs will show HTTP errors
 - Check `docker compose logs app` for error details
+
+### DATUM badge says OFFLINE but my gateway is running
+
+This is the most common DATUM-related question. The default badge is derived from
+`pool_fees_percentage`, which Ocean computes as an **average over historical work**. After you
+enable DATUM on a gateway that previously mined non-DATUM (or on a brand-new wallet with no
+history), that average can take **hours or days** to land inside the 0.9%–1.3% "DATUM range".
+During that transition window the legacy badge incorrectly reports OFFLINE.
+
+**Fix:** point the dashboard at your DATUM Gateway so it can probe it directly.
+
+- **UmbrelOS:** set `DATUM_GATEWAY_URL=http://datum_datum_1:21000` in the deepsea-dashboard
+  service environment (or `datum_gateway_url` in `config.json`).
+- **Stock self-build:** `DATUM_GATEWAY_URL=http://127.0.0.1:7152` (or wherever your gateway's
+  `api.listen_port` is bound).
+- **Bare metal on LAN:** use the gateway machine's IP + API port.
+
+With a probe configured the badge becomes:
+
+| Probe | Fees in 0.9–1.3% band | Badge |
+|---|---|---|
+| reachable | yes | `DATUM CONNECTED` (green) |
+| reachable | no | `DATUM ACTIVE (fees settling)` (amber) — this is the transition window |
+| unreachable | yes | `DATUM FEES ONLY` (amber) — your gateway process may have died |
+| unreachable | no | `DATUM OFFLINE` (red) |
+
+Without `DATUM_GATEWAY_URL` set the dashboard falls back to the legacy fee-only behaviour, so
+no setup is *required* — just recommended for anyone who recently switched on DATUM.
+
+Probe traffic is one ~2-second HTTP `GET` cached for 15 s; it never leaves your network. See
+`CONFIG.md` for the full `datum_gateway_url` reference.
 
 ### Redis connection errors
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -126,7 +126,12 @@ def get_datum_gateway_url() -> str:
     """
     import os
 
-    env_url = os.environ.get("DATUM_GATEWAY_URL", "").strip()
+    env_url = os.environ.get("DATUM_GATEWAY_URL", "").strip().rstrip("/")
     if env_url:
         return env_url
-    return load_config().get("datum_gateway_url", "")
+    # Strip + rstrip the config value too so /api/health reports
+    # ``datum_gateway_configured`` consistently with the probe, which
+    # also normalises whitespace and trailing slashes in
+    # ``datum_gateway_client._resolve_gateway_url``.
+    cfg_url = (load_config().get("datum_gateway_url") or "").strip().rstrip("/")
+    return cfg_url

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -36,6 +36,14 @@ _DEFAULTS: dict[str, Any] = {
     "network_fee": 0.5,
     "extended_history": False,
     "exchange_rate_api_key": "",
+    # Optional URL of a local DATUM Gateway (e.g.
+    # ``http://datum_datum_1:21000`` on UmbrelOS, ``http://127.0.0.1:7152``
+    # for a stock self-build).  Used by the dashboard to render a
+    # *live* DATUM connection badge that doesn't depend on the lagging
+    # ``pool_fees_percentage`` signal.  Leave blank to keep legacy
+    # fee-only behaviour.  Environment variable ``DATUM_GATEWAY_URL``
+    # overrides this field at request time.
+    "datum_gateway_url": "",
 }
 
 
@@ -108,3 +116,17 @@ def get_network_fee() -> float:
 
 def get_exchange_rate_api_key() -> str:
     return load_config().get("exchange_rate_api_key", "")
+
+
+def get_datum_gateway_url() -> str:
+    """Return the configured DATUM gateway base URL (env > config).
+
+    The env override exists so Docker/Umbrel deployments can wire this
+    via compose without touching the JSON file.
+    """
+    import os
+
+    env_url = os.environ.get("DATUM_GATEWAY_URL", "").strip()
+    if env_url:
+        return env_url
+    return load_config().get("datum_gateway_url", "")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ from app.routers import (
     blocks,
     client_errors,
     config_routes,
+    datum,
     earnings,
     exchange,
     health,
@@ -138,6 +139,7 @@ app.include_router(exchange.router, prefix=api_prefix, tags=["exchange"])
 app.include_router(client_errors.router, prefix=api_prefix, tags=["client-errors"])
 app.include_router(worker_settings.router, prefix=api_prefix, tags=["worker-settings"])
 app.include_router(batch.router, prefix=api_prefix, tags=["system"])
+app.include_router(datum.router, prefix=api_prefix, tags=["datum"])
 
 # Windows drive-letter pattern (e.g. "C:" or "D:")
 _DRIVE_RE = re.compile(r"^[A-Za-z]:")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -231,6 +231,11 @@ class AppConfig(BaseModel):
     timezone: str = "America/Los_Angeles"
     network_fee: float = Field(default=0.5, ge=0, le=100)
     extended_history: bool = False
+    # Optional base URL of a local DATUM Gateway (e.g.
+    # ``http://datum_datum_1:21000`` on UmbrelOS, ``http://127.0.0.1:7152``
+    # for a stock self-build).  Empty string disables the live probe.
+    # See CONFIG.md and the DATUM section of README.md for details.
+    datum_gateway_url: str = Field(default="", max_length=500)
 
     @field_validator("currency", mode="before")
     @classmethod
@@ -252,6 +257,7 @@ class ConfigUpdate(BaseModel):
     timezone: Optional[str] = None
     network_fee: Optional[float] = Field(default=None, ge=0, le=100)
     extended_history: Optional[bool] = None
+    datum_gateway_url: Optional[str] = Field(default=None, max_length=500)
 
     @field_validator("currency", mode="before")
     @classmethod
@@ -279,6 +285,10 @@ class HealthStatus(BaseModel):
     last_refresh: Optional[float] = None
     uptime_seconds: float = 0.0
     server_timestamp: Optional[float] = None  # Unix timestamp (seconds) for client time sync
+    # True when a DATUM gateway URL is set (env or config).  The
+    # frontend uses this to decide whether to query /api/datum/status
+    # for the live badge, or fall back to the legacy fee-only check.
+    datum_gateway_configured: bool = False
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/routers/config_routes.py
+++ b/backend/app/routers/config_routes.py
@@ -52,9 +52,9 @@ async def update_config(payload: ConfigUpdate) -> AppConfig:
     # instead of waiting up to CACHE_TTL for the stale result to age out.
     if "datum_gateway_url" in update:
         try:
-            from app.services.datum_gateway_client import _reset_cache_for_tests
+            from app.services.datum_gateway_client import clear_cache
 
-            _reset_cache_for_tests()
+            clear_cache()
         except Exception:  # pragma: no cover — defensive import guard
             pass
 

--- a/backend/app/routers/config_routes.py
+++ b/backend/app/routers/config_routes.py
@@ -32,6 +32,7 @@ async def get_config() -> AppConfig:
         timezone=cfg.get("timezone", "America/Los_Angeles"),
         network_fee=float(cfg.get("network_fee", 0.5)),
         extended_history=bool(cfg.get("extended_history", False)),
+        datum_gateway_url=cfg.get("datum_gateway_url", "") or "",
     )
 
 
@@ -45,6 +46,17 @@ async def update_config(payload: ConfigUpdate) -> AppConfig:
     """
     update = {k: v for k, v in payload.model_dump().items() if v is not None}
     await run_in_threadpool(save_config, update)
+
+    # If the DATUM gateway URL changed, drop the probe cache so the
+    # next /api/datum/status call hits the new endpoint immediately
+    # instead of waiting up to CACHE_TTL for the stale result to age out.
+    if "datum_gateway_url" in update:
+        try:
+            from app.services.datum_gateway_client import _reset_cache_for_tests
+
+            _reset_cache_for_tests()
+        except Exception:  # pragma: no cover — defensive import guard
+            pass
 
     # Fire-and-forget: don't block the response waiting for Ocean API calls
     asyncio.ensure_future(_safe_refresh())

--- a/backend/app/routers/datum.py
+++ b/backend/app/routers/datum.py
@@ -1,0 +1,158 @@
+"""GET /api/datum/status — live DATUM Gateway reachability + lagging-fee state.
+
+The dashboard's DATUM badge used to derive purely from
+``pool_fees_percentage`` (between 0.9% and 1.3% = connected).  That signal
+**lags reality** by hours or days for new DATUM users because Ocean's
+stats page averages historical work.  This endpoint surfaces a
+**current-state** signal by probing the DATUM Gateway directly, while
+still returning the fee-based signal so the UI can show a
+"transitioning" state when the two disagree.
+
+State machine returned in ``status``:
+
+- ``connected`` — probe reachable AND fees in band.  Steady-state happy path.
+- ``transitioning`` — probe reachable XOR fees in band.  Either DATUM was
+  just enabled and fees haven't caught up, OR the probe lost the gateway
+  but historical fees still look DATUM-shaped.
+- ``offline`` — probe unreachable AND fees out of band (or probe missing
+  and fees out of band).
+- ``unknown`` — no gateway URL configured and auto-discovery disabled
+  AND fees zero/unset.  The dashboard should fall back to the legacy
+  badge behaviour here so we don't regress users who never set this up.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from app import background
+from app.models import DashboardMetrics
+from app.services.datum_gateway_client import get_datum_status
+
+router = APIRouter()
+
+# These bounds match the legacy frontend isDatumConnected() check.
+# Keep them in sync if the band ever changes — there is also a copy in
+# frontend/src/pages/Dashboard.tsx.
+DATUM_FEE_BAND_LOW = 0.9
+DATUM_FEE_BAND_HIGH = 1.3
+
+
+class DatumStatus(BaseModel):
+    """Response model for ``GET /api/datum/status``.
+
+    Fields are deliberately verbose so the frontend can render an
+    informative tooltip explaining *why* the badge is the color it is —
+    that transparency is the whole point of this endpoint.
+    """
+
+    status: str  # connected | transitioning | offline | unknown
+    probe_reachable: bool
+    probe_method: str  # umbrel-api | stratum-tcp | none
+    gateway_url: Optional[str] = None
+    connections: Optional[int] = None
+    hashrate_ths: Optional[float] = None
+    pool_fees_percentage: float = 0.0
+    fees_in_datum_band: bool = False
+    fee_band_low: float = DATUM_FEE_BAND_LOW
+    fee_band_high: float = DATUM_FEE_BAND_HIGH
+    explanation: str = ""
+    last_check: float = 0.0
+    probe_error: Optional[str] = None
+
+
+def _classify(probe_reachable: bool, fees_in_band: bool, probe_method: str, fees_pct: float) -> tuple[str, str]:
+    """Combine probe + fee signals into a (status, explanation) pair.
+
+    The explanation strings are user-facing — the dashboard renders them
+    in the badge tooltip.  Keep them short and concrete; this is the
+    place where we *teach* users why the badge isn't matching their
+    expectation, which is the core ask of the bug report.
+    """
+    if probe_method == "none":
+        # No probe configured — we can only say what the fee field says.
+        if fees_in_band:
+            return (
+                "connected",
+                "Pool fees within DATUM range (no direct gateway probe configured).",
+            )
+        if fees_pct > 0:
+            return (
+                "offline",
+                "Pool fees outside DATUM range and no direct gateway probe configured. "
+                "If you just enabled DATUM, set DATUM_GATEWAY_URL so the dashboard "
+                "can confirm the gateway is up while fees catch up.",
+            )
+        return (
+            "unknown",
+            "No DATUM gateway URL configured and pool fees not yet reported.",
+        )
+
+    if probe_reachable and fees_in_band:
+        return (
+            "connected",
+            "DATUM gateway reachable and pool fees in the DATUM range.",
+        )
+    if probe_reachable and not fees_in_band:
+        # The headline bug case — DATUM is on, fees just haven't caught up.
+        return (
+            "transitioning",
+            "DATUM gateway is reachable but pool fees haven't shifted into the "
+            "DATUM range yet. Ocean averages your fee % over historical work, "
+            "so it can take hours or days after you enable DATUM for the number "
+            "to settle. Your gateway is running — this is expected.",
+        )
+    if (not probe_reachable) and fees_in_band:
+        return (
+            "transitioning",
+            "Pool fees are in the DATUM range but the gateway probe failed. "
+            "Your historical mining was via DATUM; check whether the gateway "
+            "process is still running.",
+        )
+    return (
+        "offline",
+        "DATUM gateway probe failed and pool fees are outside the DATUM range.",
+    )
+
+
+@router.get("/datum/status", response_model=DatumStatus, tags=["datum"])
+async def datum_status() -> DatumStatus:
+    """Return the current DATUM Gateway reachability + fee-band status.
+
+    Cheap to call — the underlying probe is cached for ~15 s.  Safe to
+    poll alongside ``/api/metrics``; the frontend wires this into the
+    same refresh cycle.
+    """
+    probe = await get_datum_status()
+
+    # Pull pool fees from the most recent metrics snapshot rather than
+    # making another upstream call.  Fall back to zero if the background
+    # loop hasn't populated yet.
+    raw_metrics = background.get_current_metrics() or {}
+    metrics = DashboardMetrics(**raw_metrics) if raw_metrics else DashboardMetrics()
+    fees_pct = float(metrics.pool_fees_percentage or 0.0)
+    fees_in_band = DATUM_FEE_BAND_LOW <= fees_pct <= DATUM_FEE_BAND_HIGH
+
+    status_label, explanation = _classify(
+        probe_reachable=probe.reachable,
+        fees_in_band=fees_in_band,
+        probe_method=probe.probe,
+        fees_pct=fees_pct,
+    )
+
+    return DatumStatus(
+        status=status_label,
+        probe_reachable=probe.reachable,
+        probe_method=probe.probe,
+        gateway_url=probe.gateway_url,
+        connections=probe.connections,
+        hashrate_ths=probe.hashrate_ths,
+        pool_fees_percentage=fees_pct,
+        fees_in_datum_band=fees_in_band,
+        explanation=explanation,
+        last_check=probe.checked_at,
+        probe_error=probe.reason,
+    )

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -5,7 +5,7 @@ import time
 from fastapi import APIRouter
 
 from app import background
-from app.config import get_wallet
+from app.config import get_datum_gateway_url, get_wallet
 from app.models import HealthStatus
 from app.services.cache import is_redis_connected
 
@@ -27,4 +27,5 @@ async def health_check() -> HealthStatus:
         last_refresh=background.get_last_refresh(),
         uptime_seconds=background.get_uptime(),
         server_timestamp=time.time(),
+        datum_gateway_configured=bool(get_datum_gateway_url()),
     )

--- a/backend/app/services/datum_gateway_client.py
+++ b/backend/app/services/datum_gateway_client.py
@@ -1,0 +1,387 @@
+"""Direct DATUM Gateway reachability probe.
+
+This module solves a long-standing UX problem with the dashboard's DATUM
+status indicator.  Previously the badge was derived **only** from
+``pool_fees_percentage`` (between 0.9% and 1.3% = "DATUM CONNECTED"), but
+that field is sourced from Ocean's stats page which **lags** real activity.
+
+A user who just enabled DATUM may have their gateway running and submitting
+work, yet their average pool fee won't land in the 0.9%-1.3% band until
+enough new shares accumulate to outweigh historical non-DATUM hashrate.
+During that transition window — which can last hours or days for small
+miners — the dashboard would incorrectly show "DATUM OFFLINE".
+
+This client provides a **direct, current-state** signal by probing the
+DATUM Gateway itself.  Two probe strategies, tried in order:
+
+1. **Umbrel JSON API** (``GET <base>/umbrel-api``): the gateway exposes
+   a tiny widget endpoint that returns ``{"type": "three-stats",
+   "items": [...]}`` with connection count and hashrate.  This is the
+   cleanest signal because it confirms (a) the gateway process is up,
+   (b) at least one worker is connected, and (c) we get the live
+   hashrate estimate.  Available in any build with
+   ``DATUM_API_FOR_UMBREL`` (the Umbrel app image is built this way).
+
+2. **Stratum TCP connect** (``connect <host>:<stratum_port>``): a
+   simple TCP open on the stratum port (default 23334) confirms the
+   gateway is accepting miner connections.  Used when the HTTP API is
+   not compiled in (vanilla builds) or is bound to a different host.
+
+Both probes use a tight timeout (default 2 s) so failures degrade
+quickly.  Results are cached for ``CACHE_TTL`` seconds (15 s) to keep
+hot-path latency negligible.
+
+**Configuration precedence** (highest first):
+- ``DATUM_GATEWAY_URL`` environment variable (e.g.
+  ``http://datum_datum_1:21000`` for UmbrelOS, ``http://127.0.0.1:7152``
+  for a local install).
+- ``datum_gateway_url`` in ``config.json``.
+- Auto-discovery against a small set of well-known defaults
+  (Umbrel container hostname + common local ports) if explicitly enabled
+  via ``DATUM_GATEWAY_AUTODISCOVER=1``.  Disabled by default to avoid
+  surprise outbound connections.
+
+This client never raises on network errors — failures resolve to
+``{"reachable": False, "reason": "..."}`` and the caller decides how to
+present that to the user.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import socket
+import time
+from dataclasses import dataclass, asdict
+from typing import Optional
+from urllib.parse import urlparse
+
+import httpx
+
+from app.config import load_config
+
+_log = logging.getLogger(__name__)
+
+# Cache the probe result for this many seconds.  The dashboard refreshes
+# every 30-60 s, so 15 s gives us at most one extra probe per visible
+# refresh cycle while still surfacing real outages quickly.
+CACHE_TTL = 15.0
+
+# How long any single probe is allowed to take.  Tight enough that a
+# misconfigured URL won't slow the dashboard down.
+PROBE_TIMEOUT = 2.0
+
+# Default stratum port from the upstream DATUM gateway config.
+DEFAULT_STRATUM_PORT = 23334
+
+# UmbrelOS-style defaults we'll try when auto-discovery is enabled.
+# These are intentionally narrow — we don't want to scan the user's
+# network, just check the two most common deployment shapes.
+AUTODISCOVER_CANDIDATES: tuple[str, ...] = (
+    # Umbrel container hostname (api port 21000 per their compose)
+    "http://datum_datum_1:21000",
+    # Loopback default (upstream gateway example uses 7152)
+    "http://127.0.0.1:7152",
+    # Loopback with the Umbrel port (some self-hosters reuse it)
+    "http://127.0.0.1:21000",
+)
+
+
+@dataclass
+class DatumProbeResult:
+    """One probe attempt's outcome.
+
+    Attributes:
+        reachable: ``True`` if any probe succeeded.
+        status: Coarse label: ``connected`` | ``offline`` | ``unknown``.
+            ``unknown`` means no URL was configured and auto-discovery is
+            off, so we cannot make any statement about reachability.
+        probe: Which method produced the result
+            (``umbrel-api`` | ``stratum-tcp`` | ``none``).
+        gateway_url: The URL we actually probed (may be auto-discovered).
+        connections: Worker connection count (only via umbrel-api).
+        hashrate_ths: Estimated hashrate in TH/s (only via umbrel-api).
+        reason: Short human-readable error if not reachable.
+        checked_at: Unix timestamp of the probe.
+    """
+
+    reachable: bool
+    status: str
+    probe: str
+    gateway_url: Optional[str]
+    connections: Optional[int] = None
+    hashrate_ths: Optional[float] = None
+    reason: Optional[str] = None
+    checked_at: float = 0.0
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+# Module-level cache.  Single in-process; the background refresh loop
+# also calls into here so this stays warm without per-request work.
+_cached_result: Optional[DatumProbeResult] = None
+_cached_at: float = 0.0
+_probe_lock = asyncio.Lock()
+
+
+def _resolve_gateway_url() -> Optional[str]:
+    """Return the configured DATUM gateway base URL, or None."""
+    env_url = os.environ.get("DATUM_GATEWAY_URL", "").strip()
+    if env_url:
+        return env_url.rstrip("/")
+    try:
+        cfg = load_config()
+    except Exception:  # pragma: no cover — load_config is defensive itself
+        return None
+    cfg_url = (cfg.get("datum_gateway_url") or "").strip()
+    if cfg_url:
+        return cfg_url.rstrip("/")
+    return None
+
+
+def _autodiscover_enabled() -> bool:
+    return os.environ.get("DATUM_GATEWAY_AUTODISCOVER", "").lower() in {"1", "true", "yes"}
+
+
+def _parse_hashrate_ths(text: str, unit: str) -> Optional[float]:
+    """Convert the gateway's ``"%.2f %s"`` hashrate to TH/s.
+
+    The umbrel-api widget formats hashrate via the gateway's
+    ``dynamic_hash_unit`` helper, which yields units like ``H/s``, ``KH/s``,
+    ``MH/s``, ``GH/s``, ``TH/s``, ``PH/s``, ``EH/s``.  We normalise to TH/s
+    so the dashboard can render it next to the existing TH/s metrics.
+    """
+    try:
+        value = float(text)
+    except (TypeError, ValueError):
+        return None
+    unit_u = (unit or "").strip().upper()
+    multipliers = {
+        "H/S": 1e-12,
+        "KH/S": 1e-9,
+        "MH/S": 1e-6,
+        "GH/S": 1e-3,
+        "TH/S": 1.0,
+        "PH/S": 1e3,
+        "EH/S": 1e6,
+    }
+    factor = multipliers.get(unit_u)
+    if factor is None:
+        # Unknown unit — surface the raw number so we don't lie about
+        # magnitude.  Callers should check the unit field separately
+        # if they need certainty.
+        return value
+    return value * factor
+
+
+async def _probe_umbrel_api(base_url: str) -> DatumProbeResult:
+    """Probe ``<base_url>/umbrel-api`` and parse the JSON widget payload."""
+    url = f"{base_url}/umbrel-api"
+    try:
+        async with httpx.AsyncClient(timeout=PROBE_TIMEOUT) as client:
+            resp = await client.get(url)
+    except (httpx.RequestError, asyncio.TimeoutError) as e:
+        return DatumProbeResult(
+            reachable=False,
+            status="offline",
+            probe="umbrel-api",
+            gateway_url=base_url,
+            reason=f"http-error: {type(e).__name__}",
+            checked_at=time.time(),
+        )
+
+    if resp.status_code != 200:
+        return DatumProbeResult(
+            reachable=False,
+            status="offline",
+            probe="umbrel-api",
+            gateway_url=base_url,
+            reason=f"http-{resp.status_code}",
+            checked_at=time.time(),
+        )
+
+    try:
+        body = resp.json()
+    except ValueError:
+        return DatumProbeResult(
+            reachable=False,
+            status="offline",
+            probe="umbrel-api",
+            gateway_url=base_url,
+            reason="invalid-json",
+            checked_at=time.time(),
+        )
+
+    items = body.get("items") or []
+    connections: Optional[int] = None
+    hashrate_ths: Optional[float] = None
+    for item in items:
+        title = (item.get("title") or "").lower()
+        text = item.get("text")
+        subtext = item.get("subtext")
+        if title == "connections":
+            try:
+                connections = int(text)
+            except (TypeError, ValueError):
+                connections = None
+        elif title == "hashrate":
+            hashrate_ths = _parse_hashrate_ths(text, subtext or "")
+
+    # Gateway is up if it answered the API at all.  Connections == 0 is
+    # still "reachable" — the daemon is alive, no miners hooked up yet.
+    # We surface the count so the UI can show it.
+    return DatumProbeResult(
+        reachable=True,
+        status="connected",
+        probe="umbrel-api",
+        gateway_url=base_url,
+        connections=connections,
+        hashrate_ths=hashrate_ths,
+        checked_at=time.time(),
+    )
+
+
+async def _probe_stratum_tcp(base_url: str, stratum_port: int = DEFAULT_STRATUM_PORT) -> DatumProbeResult:
+    """TCP-connect to the stratum port to verify the gateway is listening.
+
+    Uses the hostname from ``base_url`` (or, if no URL is set, the caller
+    can pass in a host-only URL like ``tcp://127.0.0.1``).  Does **not**
+    speak Stratum — opening the socket is sufficient evidence the gateway
+    is accepting connections.
+    """
+    parsed = urlparse(base_url)
+    host = parsed.hostname or "127.0.0.1"
+
+    loop = asyncio.get_running_loop()
+    try:
+        await asyncio.wait_for(
+            loop.run_in_executor(None, _blocking_tcp_check, host, stratum_port),
+            timeout=PROBE_TIMEOUT,
+        )
+    except (asyncio.TimeoutError, OSError) as e:
+        return DatumProbeResult(
+            reachable=False,
+            status="offline",
+            probe="stratum-tcp",
+            gateway_url=base_url,
+            reason=f"tcp-error: {type(e).__name__}",
+            checked_at=time.time(),
+        )
+
+    return DatumProbeResult(
+        reachable=True,
+        status="connected",
+        probe="stratum-tcp",
+        gateway_url=base_url,
+        checked_at=time.time(),
+    )
+
+
+def _blocking_tcp_check(host: str, port: int) -> None:
+    """Open and close a TCP socket; raises on failure.
+
+    Pulled out as a separate function so we can run it in an executor —
+    ``socket.create_connection`` is blocking and we don't want to depend
+    on platform asyncio resolver edge cases for this short check.
+    """
+    with socket.create_connection((host, port), timeout=PROBE_TIMEOUT):
+        pass
+
+
+async def _do_probe() -> DatumProbeResult:
+    """Run the configured probe(s) and return the best result.
+
+    Order of operations:
+    1. Explicit URL (env or config) — try umbrel-api, then stratum-tcp.
+    2. Auto-discovery (only if ``DATUM_GATEWAY_AUTODISCOVER=1``) — try
+       each candidate against umbrel-api until one succeeds.
+    3. Nothing configured + auto-discovery off → ``unknown`` status.
+    """
+    base_url = _resolve_gateway_url()
+
+    if base_url:
+        # Try the rich JSON probe first.
+        result = await _probe_umbrel_api(base_url)
+        if result.reachable:
+            return result
+        # Fall back to a simple TCP connect on the stratum port.  Use the
+        # same host the user pointed us at — they may have a build
+        # without DATUM_API_FOR_UMBREL but still expose stratum.
+        tcp_result = await _probe_stratum_tcp(base_url)
+        if tcp_result.reachable:
+            return tcp_result
+        # Both failed — return the more informative HTTP result.
+        return result
+
+    if _autodiscover_enabled():
+        for candidate in AUTODISCOVER_CANDIDATES:
+            result = await _probe_umbrel_api(candidate)
+            if result.reachable:
+                return result
+        return DatumProbeResult(
+            reachable=False,
+            status="offline",
+            probe="none",
+            gateway_url=None,
+            reason="autodiscover-failed",
+            checked_at=time.time(),
+        )
+
+    return DatumProbeResult(
+        reachable=False,
+        status="unknown",
+        probe="none",
+        gateway_url=None,
+        reason="not-configured",
+        checked_at=time.time(),
+    )
+
+
+async def get_datum_status(force: bool = False) -> DatumProbeResult:
+    """Return the cached probe result, refreshing if stale or forced.
+
+    Args:
+        force: If ``True``, bypass the cache and run a fresh probe.
+
+    Returns:
+        :class:`DatumProbeResult` — never raises.
+    """
+    global _cached_result, _cached_at
+
+    now = time.time()
+    if not force and _cached_result is not None and (now - _cached_at) < CACHE_TTL:
+        return _cached_result
+
+    # Single-flight: if many requests hit at once during refresh, let
+    # exactly one of them do the work.
+    async with _probe_lock:
+        # Re-check inside the lock — another caller may have refreshed.
+        now = time.time()
+        if not force and _cached_result is not None and (now - _cached_at) < CACHE_TTL:
+            return _cached_result
+
+        try:
+            result = await _do_probe()
+        except Exception as e:  # pragma: no cover — last-resort guard
+            _log.warning("DATUM probe unexpectedly raised: %s", e)
+            result = DatumProbeResult(
+                reachable=False,
+                status="unknown",
+                probe="none",
+                gateway_url=_resolve_gateway_url(),
+                reason=f"probe-exception: {type(e).__name__}",
+                checked_at=time.time(),
+            )
+
+        _cached_result = result
+        _cached_at = result.checked_at
+        return result
+
+
+def _reset_cache_for_tests() -> None:
+    """Clear the module cache.  Tests should call this between scenarios."""
+    global _cached_result, _cached_at
+    _cached_result = None
+    _cached_at = 0.0

--- a/backend/app/services/datum_gateway_client.py
+++ b/backend/app/services/datum_gateway_client.py
@@ -49,6 +49,7 @@ present that to the user.
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import logging
 import os
 import socket
@@ -126,18 +127,127 @@ _cached_at: float = 0.0
 _probe_lock = asyncio.Lock()
 
 
+# Hostnames that resolve to in-cluster Docker services we expect users to
+# point at on Umbrel / Start9 / docker-compose setups.  These bypass the
+# IP-literal allowlist because Docker's embedded DNS only resolves them
+# inside the user's own container network.
+_TRUSTED_DOCKER_HOSTS: frozenset[str] = frozenset(
+    {
+        "datum_datum_1",
+        "datum_gateway",
+        "datum",
+        "datum_web_1",
+    }
+)
+
+
+def _is_safe_gateway_host(host: str) -> tuple[bool, str]:
+    """Return ``(ok, reason)`` for a candidate gateway host.
+
+    The DATUM gateway URL is user-controlled via the unauthenticated
+    ``/api/config`` endpoint, and the resolved URL is fed directly into
+    outbound HTTP and TCP connects.  Without this guard the probe is an
+    SSRF and port-scan primitive: an attacker who can reach
+    ``/api/config`` could point the dashboard at cloud-metadata
+    endpoints (``169.254.169.254``), an arbitrary LAN host, or an
+    internal API on localhost.
+
+    Policy: allow only loopback, RFC1918 private ranges, and a small
+    set of well-known Docker service names.  Reject link-local,
+    multicast, public IPs, and anything we can't classify.
+    """
+    if not host:
+        return False, "empty-host"
+
+    h = host.strip().lower()
+
+    # Strip an optional ``[ipv6]`` bracket form that urlparse already
+    # removes, but be defensive in case callers pass a raw string.
+    if h.startswith("[") and h.endswith("]"):
+        h = h[1:-1]
+
+    # Allow a curated list of Docker service hostnames — these only
+    # resolve inside the user's own container network.
+    if h in _TRUSTED_DOCKER_HOSTS:
+        return True, "docker-service"
+
+    # If it parses as an IP literal, classify it.
+    try:
+        ip = ipaddress.ip_address(h)
+    except ValueError:
+        # Not an IP — reject unrecognised hostnames.  We don't do DNS
+        # lookups here because (a) that's another network round-trip
+        # before the probe, and (b) an attacker controls the hostname
+        # and could trivially defeat a one-shot resolve via TTL games.
+        return False, "unrecognised-host"
+
+    if ip.is_loopback:
+        return True, "loopback"
+    if ip.is_link_local:
+        return False, "link-local"  # blocks 169.254.169.254 metadata
+    if ip.is_multicast:
+        return False, "multicast"
+    if ip.is_unspecified:
+        return False, "unspecified"  # 0.0.0.0 / ::
+    if ip.is_reserved:
+        return False, "reserved"
+    if ip.is_private:
+        return True, "private"
+    return False, "public-ip"
+
+
+def _validate_gateway_url(url: str) -> Optional[str]:
+    """Normalise + validate a candidate gateway URL.
+
+    Returns the cleaned URL string when the URL is shaped like
+    ``http(s)://<safe-host>[:port][/...]``, otherwise ``None``.  Logs a
+    warning when a URL is rejected so misconfiguration is debuggable.
+    """
+    if not url:
+        return None
+    cleaned = url.strip().rstrip("/")
+    if not cleaned:
+        return None
+    try:
+        parsed = urlparse(cleaned)
+    except ValueError:
+        _log.warning("DATUM gateway URL rejected (unparseable): %r", url)
+        return None
+    if parsed.scheme not in {"http", "https"}:
+        _log.warning("DATUM gateway URL rejected (bad scheme %r)", parsed.scheme)
+        return None
+    host = parsed.hostname or ""
+    ok, reason = _is_safe_gateway_host(host)
+    if not ok:
+        _log.warning(
+            "DATUM gateway URL rejected (host=%r reason=%s)", host, reason
+        )
+        return None
+    return cleaned
+
+
 def _resolve_gateway_url() -> Optional[str]:
-    """Return the configured DATUM gateway base URL, or None."""
+    """Return the configured DATUM gateway base URL, or None.
+
+    Validates against :func:`_is_safe_gateway_host` so a user-supplied
+    ``datum_gateway_url`` cannot turn the probe into an SSRF / port
+    scanner.  Invalid URLs are logged and treated as "not configured".
+    """
     env_url = os.environ.get("DATUM_GATEWAY_URL", "").strip()
     if env_url:
-        return env_url.rstrip("/")
+        validated = _validate_gateway_url(env_url)
+        if validated:
+            return validated
+        # Fall through to config if env was invalid; this matches the
+        # "env > config" precedence while still letting a sane config
+        # value win if the env is garbage.
     try:
         cfg = load_config()
     except Exception:  # pragma: no cover — load_config is defensive itself
         return None
     cfg_url = (cfg.get("datum_gateway_url") or "").strip()
     if cfg_url:
-        return cfg_url.rstrip("/")
+        return _validate_gateway_url(cfg_url)
     return None
 
 
@@ -169,10 +279,12 @@ def _parse_hashrate_ths(text: str, unit: str) -> Optional[float]:
     }
     factor = multipliers.get(unit_u)
     if factor is None:
-        # Unknown unit — surface the raw number so we don't lie about
-        # magnitude.  Callers should check the unit field separately
-        # if they need certainty.
-        return value
+        # Unknown unit — return None rather than the raw number, which
+        # would silently misreport hashrate magnitude (the result is
+        # stored in ``hashrate_ths``).  If the gateway ever ships a new
+        # unit we'd rather show "unknown" than a wrong number.
+        _log.warning("DATUM probe: unknown hashrate unit %r (value=%r)", unit, text)
+        return None
     return value * factor
 
 
@@ -380,8 +492,21 @@ async def get_datum_status(force: bool = False) -> DatumProbeResult:
         return result
 
 
-def _reset_cache_for_tests() -> None:
-    """Clear the module cache.  Tests should call this between scenarios."""
+def clear_cache() -> None:
+    """Invalidate the module-level probe cache.
+
+    Public API — call this whenever the gateway URL or any other input
+    to ``_do_probe`` changes (e.g. ``/api/config`` updates the URL) so
+    the next ``get_datum_status`` call runs a fresh probe instead of
+    waiting up to :data:`CACHE_TTL` for the stale result to age out.
+    """
     global _cached_result, _cached_at
     _cached_result = None
     _cached_at = 0.0
+
+
+# Backwards-compatible alias.  Tests imported this name before
+# ``clear_cache`` existed; keep it working until external tests catch up.
+def _reset_cache_for_tests() -> None:
+    """Deprecated alias for :func:`clear_cache` — kept for test backcompat."""
+    clear_cache()

--- a/backend/tests/test_datum_gateway.py
+++ b/backend/tests/test_datum_gateway.py
@@ -1,0 +1,424 @@
+"""Tests for the DATUM gateway probe + /api/datum/status endpoint.
+
+These cover the bug the feature was built for: pool_fees_percentage lags
+real DATUM activation, so a freshly-enabled gateway used to show
+"DATUM OFFLINE" until Ocean's stats caught up.  The probe + state
+machine should now surface a "transitioning" state instead.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app import background
+from app.main import app
+from app.services import datum_gateway_client as dgc
+
+
+@pytest_asyncio.fixture
+async def client():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def reset_probe_cache():
+    """Always start each test with a clean probe cache."""
+    dgc._reset_cache_for_tests()
+    yield
+    dgc._reset_cache_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# _parse_hashrate_ths
+# ---------------------------------------------------------------------------
+
+def test_parse_hashrate_ths_converts_known_units():
+    assert dgc._parse_hashrate_ths("1.50", "TH/s") == pytest.approx(1.5)
+    assert dgc._parse_hashrate_ths("500", "GH/s") == pytest.approx(0.5)
+    assert dgc._parse_hashrate_ths("2.0", "PH/s") == pytest.approx(2000.0)
+    assert dgc._parse_hashrate_ths("1000", "MH/s") == pytest.approx(0.001)
+
+
+def test_parse_hashrate_ths_handles_bad_input():
+    assert dgc._parse_hashrate_ths("not-a-number", "TH/s") is None
+    assert dgc._parse_hashrate_ths(None, "TH/s") is None  # type: ignore[arg-type]
+
+
+def test_parse_hashrate_ths_returns_raw_for_unknown_unit():
+    # We surface the raw number rather than silently dropping it; the
+    # caller can still inspect the original unit if it really cares.
+    assert dgc._parse_hashrate_ths("42", "WIDGETS/s") == 42.0
+
+
+# ---------------------------------------------------------------------------
+# umbrel-api probe
+# ---------------------------------------------------------------------------
+
+class _FakeAsyncClient:
+    """Minimal httpx.AsyncClient stand-in for parametrised probe tests."""
+
+    def __init__(self, response=None, exc=None):
+        self._response = response
+        self._exc = exc
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+    async def get(self, _url):
+        if self._exc is not None:
+            raise self._exc
+        return self._response
+
+
+def _resp(status=200, json_body=None):
+    """Build a minimal httpx-like response for the probe to consume."""
+    r = SimpleNamespace()
+    r.status_code = status
+    r.json = lambda: json_body if json_body is not None else {}
+    return r
+
+
+@pytest.mark.asyncio
+async def test_probe_umbrel_api_happy_path(monkeypatch):
+    """Reachable gateway with connections + hashrate is parsed correctly."""
+    body = {
+        "type": "three-stats",
+        "items": [
+            {"title": "Connections", "text": "3", "subtext": "Worker"},
+            {"title": "Hashrate", "text": "1.25", "subtext": "PH/s"},
+        ],
+    }
+    monkeypatch.setattr(httpx, "AsyncClient", lambda timeout=None: _FakeAsyncClient(response=_resp(200, body)))
+
+    result = await dgc._probe_umbrel_api("http://datum_datum_1:21000")
+
+    assert result.reachable is True
+    assert result.status == "connected"
+    assert result.probe == "umbrel-api"
+    assert result.connections == 3
+    # 1.25 PH/s == 1250 TH/s
+    assert result.hashrate_ths == pytest.approx(1250.0)
+    assert result.reason is None
+
+
+@pytest.mark.asyncio
+async def test_probe_umbrel_api_reachable_with_zero_workers(monkeypatch):
+    """Gateway up but no miners attached \u2014 still 'connected' (daemon alive)."""
+    body = {
+        "items": [
+            {"title": "Connections", "text": "0", "subtext": "Worker"},
+            {"title": "Hashrate", "text": "0.00", "subtext": "TH/s"},
+        ],
+    }
+    monkeypatch.setattr(httpx, "AsyncClient", lambda timeout=None: _FakeAsyncClient(response=_resp(200, body)))
+
+    result = await dgc._probe_umbrel_api("http://127.0.0.1:21000")
+    assert result.reachable is True
+    assert result.connections == 0
+    assert result.hashrate_ths == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_probe_umbrel_api_http_error(monkeypatch):
+    monkeypatch.setattr(httpx, "AsyncClient", lambda timeout=None: _FakeAsyncClient(response=_resp(503)))
+    result = await dgc._probe_umbrel_api("http://127.0.0.1:21000")
+    assert result.reachable is False
+    assert "http-503" in (result.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_probe_umbrel_api_connect_error(monkeypatch):
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda timeout=None: _FakeAsyncClient(exc=httpx.ConnectError("nope")),
+    )
+    result = await dgc._probe_umbrel_api("http://127.0.0.1:21000")
+    assert result.reachable is False
+    assert result.reason and result.reason.startswith("http-error")
+
+
+@pytest.mark.asyncio
+async def test_probe_umbrel_api_invalid_json(monkeypatch):
+    bad_resp = SimpleNamespace()
+    bad_resp.status_code = 200
+
+    def _raise_json():
+        raise ValueError("nope")
+
+    bad_resp.json = _raise_json
+    monkeypatch.setattr(httpx, "AsyncClient", lambda timeout=None: _FakeAsyncClient(response=bad_resp))
+    result = await dgc._probe_umbrel_api("http://127.0.0.1:21000")
+    assert result.reachable is False
+    assert result.reason == "invalid-json"
+
+
+# ---------------------------------------------------------------------------
+# stratum-tcp probe
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_probe_stratum_tcp_success(monkeypatch):
+    """A successful TCP connect makes the gateway 'reachable' via stratum."""
+    def fake_check(host, port):
+        assert host == "127.0.0.1"
+        assert port == dgc.DEFAULT_STRATUM_PORT
+        return None
+
+    monkeypatch.setattr(dgc, "_blocking_tcp_check", fake_check)
+    result = await dgc._probe_stratum_tcp("http://127.0.0.1:21000")
+    assert result.reachable is True
+    assert result.probe == "stratum-tcp"
+
+
+@pytest.mark.asyncio
+async def test_probe_stratum_tcp_refused(monkeypatch):
+    def fake_check(host, port):
+        raise ConnectionRefusedError("nope")
+
+    monkeypatch.setattr(dgc, "_blocking_tcp_check", fake_check)
+    result = await dgc._probe_stratum_tcp("http://127.0.0.1:21000")
+    assert result.reachable is False
+    assert result.reason and "ConnectionRefusedError" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# get_datum_status cache + dispatch
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_datum_status_no_config_returns_unknown(monkeypatch):
+    """Nothing configured + autodiscover off \u2014 status is 'unknown'."""
+    monkeypatch.delenv("DATUM_GATEWAY_URL", raising=False)
+    monkeypatch.delenv("DATUM_GATEWAY_AUTODISCOVER", raising=False)
+    monkeypatch.setattr(dgc, "load_config", lambda: {"datum_gateway_url": ""})
+
+    result = await dgc.get_datum_status(force=True)
+    assert result.reachable is False
+    assert result.status == "unknown"
+    assert result.probe == "none"
+    assert result.reason == "not-configured"
+
+
+@pytest.mark.asyncio
+async def test_get_datum_status_uses_env_override(monkeypatch):
+    """Env var beats config file."""
+    monkeypatch.setenv("DATUM_GATEWAY_URL", "http://gateway.local:7152")
+    monkeypatch.setattr(dgc, "load_config", lambda: {"datum_gateway_url": "http://other:1234"})
+
+    body = {"items": [{"title": "Connections", "text": "1"}, {"title": "Hashrate", "text": "1", "subtext": "TH/s"}]}
+    seen_urls = []
+
+    class _Capturing(_FakeAsyncClient):
+        async def get(self, url):
+            seen_urls.append(url)
+            return _resp(200, body)
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda timeout=None: _Capturing(response=_resp(200, body)))
+
+    result = await dgc.get_datum_status(force=True)
+    assert result.reachable is True
+    assert result.gateway_url == "http://gateway.local:7152"
+    assert seen_urls == ["http://gateway.local:7152/umbrel-api"]
+
+
+@pytest.mark.asyncio
+async def test_get_datum_status_falls_back_to_tcp(monkeypatch):
+    """If umbrel-api fails (e.g. vanilla build), TCP-connect on stratum is tried."""
+    monkeypatch.setenv("DATUM_GATEWAY_URL", "http://127.0.0.1:7152")
+
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda timeout=None: _FakeAsyncClient(exc=httpx.ConnectError("api closed")),
+    )
+
+    def fake_tcp(host, port):
+        return None  # success
+
+    monkeypatch.setattr(dgc, "_blocking_tcp_check", fake_tcp)
+
+    result = await dgc.get_datum_status(force=True)
+    assert result.reachable is True
+    assert result.probe == "stratum-tcp"
+
+
+@pytest.mark.asyncio
+async def test_get_datum_status_caches_results(monkeypatch):
+    """Repeat calls within CACHE_TTL must not re-probe."""
+    monkeypatch.setenv("DATUM_GATEWAY_URL", "http://127.0.0.1:21000")
+
+    call_count = {"n": 0}
+    body = {"items": [{"title": "Connections", "text": "1"}, {"title": "Hashrate", "text": "1", "subtext": "TH/s"}]}
+
+    class _Counting(_FakeAsyncClient):
+        async def get(self, url):
+            call_count["n"] += 1
+            return _resp(200, body)
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda timeout=None: _Counting(response=_resp(200, body)))
+
+    first = await dgc.get_datum_status(force=True)
+    second = await dgc.get_datum_status()  # no force \u2014 should hit cache
+    third = await dgc.get_datum_status()
+
+    assert call_count["n"] == 1, "second/third calls should be cached"
+    assert first.checked_at == second.checked_at == third.checked_at
+
+
+# ---------------------------------------------------------------------------
+# /api/datum/status endpoint \u2014 the full state machine
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_endpoint_connected_when_probe_and_fees_agree(client, monkeypatch):
+    """Steady-state happy path \u2014 probe up AND fees in band."""
+    monkeypatch.setattr(
+        "app.routers.datum.get_datum_status",
+        _async_returning(dgc.DatumProbeResult(
+            reachable=True,
+            status="connected",
+            probe="umbrel-api",
+            gateway_url="http://127.0.0.1:21000",
+            connections=2,
+            hashrate_ths=120.0,
+            checked_at=1.0,
+        )),
+    )
+    monkeypatch.setattr(background, "get_current_metrics", lambda: {"pool_fees_percentage": 1.05})
+
+    resp = await client.get("/api/datum/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "connected"
+    assert data["probe_reachable"] is True
+    assert data["fees_in_datum_band"] is True
+    assert data["connections"] == 2
+
+
+@pytest.mark.asyncio
+async def test_endpoint_transitioning_when_probe_up_but_fees_lag(client, monkeypatch):
+    """The headline bug: DATUM just enabled, fees haven't caught up."""
+    monkeypatch.setattr(
+        "app.routers.datum.get_datum_status",
+        _async_returning(dgc.DatumProbeResult(
+            reachable=True,
+            status="connected",
+            probe="umbrel-api",
+            gateway_url="http://127.0.0.1:21000",
+            connections=1,
+            hashrate_ths=2.0,
+            checked_at=2.0,
+        )),
+    )
+    # Fee % well below the 0.9% threshold \u2014 mimics a brand-new DATUM user.
+    monkeypatch.setattr(background, "get_current_metrics", lambda: {"pool_fees_percentage": 0.05})
+
+    resp = await client.get("/api/datum/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "transitioning"
+    assert data["probe_reachable"] is True
+    assert data["fees_in_datum_band"] is False
+    # The user-facing explanation should call out the lagging-fee root cause.
+    assert "hours" in data["explanation"].lower() or "fees" in data["explanation"].lower()
+
+
+@pytest.mark.asyncio
+async def test_endpoint_transitioning_when_fees_in_band_but_probe_down(client, monkeypatch):
+    """Inverse case: fees still look DATUM-shaped but probe is failing."""
+    monkeypatch.setattr(
+        "app.routers.datum.get_datum_status",
+        _async_returning(dgc.DatumProbeResult(
+            reachable=False,
+            status="offline",
+            probe="umbrel-api",
+            gateway_url="http://127.0.0.1:21000",
+            reason="http-error: ConnectError",
+            checked_at=3.0,
+        )),
+    )
+    monkeypatch.setattr(background, "get_current_metrics", lambda: {"pool_fees_percentage": 1.0})
+
+    resp = await client.get("/api/datum/status")
+    data = resp.json()
+    assert data["status"] == "transitioning"
+    assert data["probe_reachable"] is False
+
+
+@pytest.mark.asyncio
+async def test_endpoint_offline_when_both_signals_negative(client, monkeypatch):
+    monkeypatch.setattr(
+        "app.routers.datum.get_datum_status",
+        _async_returning(dgc.DatumProbeResult(
+            reachable=False,
+            status="offline",
+            probe="umbrel-api",
+            gateway_url="http://127.0.0.1:21000",
+            reason="http-error: ConnectError",
+            checked_at=4.0,
+        )),
+    )
+    monkeypatch.setattr(background, "get_current_metrics", lambda: {"pool_fees_percentage": 2.0})
+
+    resp = await client.get("/api/datum/status")
+    data = resp.json()
+    assert data["status"] == "offline"
+
+
+@pytest.mark.asyncio
+async def test_endpoint_unknown_when_no_probe_and_no_fees(client, monkeypatch):
+    """No probe configured, no fee data yet \u2014 'unknown' rather than a false claim."""
+    monkeypatch.setattr(
+        "app.routers.datum.get_datum_status",
+        _async_returning(dgc.DatumProbeResult(
+            reachable=False,
+            status="unknown",
+            probe="none",
+            gateway_url=None,
+            reason="not-configured",
+            checked_at=5.0,
+        )),
+    )
+    monkeypatch.setattr(background, "get_current_metrics", lambda: {"pool_fees_percentage": 0.0})
+
+    resp = await client.get("/api/datum/status")
+    data = resp.json()
+    assert data["status"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_reports_datum_configured_flag(client, monkeypatch):
+    """The Dashboard reads /health to decide whether to poll /datum/status."""
+    monkeypatch.setattr("app.routers.health.get_datum_gateway_url", lambda: "http://127.0.0.1:21000")
+    resp = await client.get("/api/health")
+    assert resp.status_code == 200
+    assert resp.json()["datum_gateway_configured"] is True
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_reports_no_datum_when_unset(client, monkeypatch):
+    monkeypatch.setattr("app.routers.health.get_datum_gateway_url", lambda: "")
+    resp = await client.get("/api/health")
+    assert resp.status_code == 200
+    assert resp.json()["datum_gateway_configured"] is False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _async_returning(value):
+    """Build an async function that returns ``value`` regardless of args."""
+    async def _f(*_a, **_kw):
+        return value
+    return _f

--- a/backend/tests/test_datum_gateway.py
+++ b/backend/tests/test_datum_gateway.py
@@ -50,10 +50,97 @@ def test_parse_hashrate_ths_handles_bad_input():
     assert dgc._parse_hashrate_ths(None, "TH/s") is None  # type: ignore[arg-type]
 
 
-def test_parse_hashrate_ths_returns_raw_for_unknown_unit():
-    # We surface the raw number rather than silently dropping it; the
-    # caller can still inspect the original unit if it really cares.
-    assert dgc._parse_hashrate_ths("42", "WIDGETS/s") == 42.0
+def test_parse_hashrate_ths_returns_none_for_unknown_unit():
+    # Unknown units must return None rather than the raw value.  The
+    # result lands in ``hashrate_ths`` so passing through an
+    # unconverted number would silently misreport magnitude if the
+    # gateway ever ships a unit we don't recognise.
+    assert dgc._parse_hashrate_ths("42", "WIDGETS/s") is None
+    assert dgc._parse_hashrate_ths("42", "") is None
+
+
+# ---------------------------------------------------------------------------
+# SSRF guard on _resolve_gateway_url / _validate_gateway_url
+# ---------------------------------------------------------------------------
+
+class TestGatewayUrlValidation:
+    """The DATUM gateway URL is user-controlled via /api/config, so we
+    must refuse to probe arbitrary destinations."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1:7152",
+            "http://127.0.0.1:21000/",
+            "http://10.0.0.5:21000",
+            "http://192.168.1.42:7152",
+            "http://172.16.5.5:7152",
+            "http://[::1]:7152",
+            "http://datum_datum_1:21000",
+            "https://datum_datum_1:21000",
+        ],
+    )
+    def test_accepts_safe_hosts(self, url):
+        assert dgc._validate_gateway_url(url) is not None
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            # Link-local / cloud metadata
+            "http://169.254.169.254/latest/meta-data/",
+            "http://169.254.0.1:80",
+            # Public Internet
+            "http://8.8.8.8:80",
+            "http://example.com:80",
+            "http://attacker.example/",
+            # Bad schemes
+            "file:///etc/passwd",
+            "gopher://127.0.0.1:21000",
+            "ftp://127.0.0.1:21000",
+            # Multicast / unspecified / reserved
+            "http://224.0.0.1:80",
+            "http://0.0.0.0:80",
+            # Garbage
+            "not-a-url",
+            "",
+            "   ",
+        ],
+    )
+    def test_rejects_unsafe_hosts(self, url):
+        assert dgc._validate_gateway_url(url) is None
+
+    def test_resolve_drops_unsafe_env(self, monkeypatch):
+        """An attacker-controlled env var pointing at metadata IP is rejected."""
+        monkeypatch.setenv("DATUM_GATEWAY_URL", "http://169.254.169.254/")
+        monkeypatch.setattr(dgc, "load_config", lambda: {"datum_gateway_url": ""})
+        assert dgc._resolve_gateway_url() is None
+
+    def test_resolve_drops_unsafe_config(self, monkeypatch):
+        """Same protection for a /api/config-supplied value."""
+        monkeypatch.delenv("DATUM_GATEWAY_URL", raising=False)
+        monkeypatch.setattr(
+            dgc,
+            "load_config",
+            lambda: {"datum_gateway_url": "http://attacker.example/"},
+        )
+        assert dgc._resolve_gateway_url() is None
+
+    def test_resolve_normalises_trailing_slash(self, monkeypatch):
+        monkeypatch.setenv("DATUM_GATEWAY_URL", "http://127.0.0.1:7152/")
+        assert dgc._resolve_gateway_url() == "http://127.0.0.1:7152"
+
+
+def test_clear_cache_is_public_alias():
+    """``clear_cache`` is the production-safe public name; the
+    legacy ``_reset_cache_for_tests`` alias stays for backcompat."""
+    assert callable(dgc.clear_cache)
+    assert callable(dgc._reset_cache_for_tests)
+    # Populate the cache, then both names should clear it.
+    dgc._cached_result = object()  # type: ignore[assignment]
+    dgc._cached_at = 1.0
+    dgc.clear_cache()
+    assert dgc._cached_result is None
+    assert dgc._cached_at == 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -212,8 +299,10 @@ async def test_get_datum_status_no_config_returns_unknown(monkeypatch):
 @pytest.mark.asyncio
 async def test_get_datum_status_uses_env_override(monkeypatch):
     """Env var beats config file."""
-    monkeypatch.setenv("DATUM_GATEWAY_URL", "http://gateway.local:7152")
-    monkeypatch.setattr(dgc, "load_config", lambda: {"datum_gateway_url": "http://other:1234"})
+    # Use loopback / RFC1918 hosts because the SSRF guard rejects
+    # arbitrary hostnames — the env override behaviour is unchanged.
+    monkeypatch.setenv("DATUM_GATEWAY_URL", "http://127.0.0.1:7152")
+    monkeypatch.setattr(dgc, "load_config", lambda: {"datum_gateway_url": "http://10.0.0.5:1234"})
 
     body = {"items": [{"title": "Connections", "text": "1"}, {"title": "Hashrate", "text": "1", "subtext": "TH/s"}]}
     seen_urls = []
@@ -227,8 +316,8 @@ async def test_get_datum_status_uses_env_override(monkeypatch):
 
     result = await dgc.get_datum_status(force=True)
     assert result.reachable is True
-    assert result.gateway_url == "http://gateway.local:7152"
-    assert seen_urls == ["http://gateway.local:7152/umbrel-api"]
+    assert result.gateway_url == "http://127.0.0.1:7152"
+    assert seen_urls == ["http://127.0.0.1:7152/umbrel-api"]
 
 
 @pytest.mark.asyncio

--- a/config.json.example
+++ b/config.json.example
@@ -7,6 +7,7 @@
   "network_fee": 2.0,
   "extended_history": false,
   "exchange_rate_api_key": "",
+  "datum_gateway_url": "",
   "low_hashrate_threshold_ths": 3.0,
   "high_hashrate_threshold_ths": 20.0
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -4,6 +4,7 @@ import type {
   AppConfig,
   BlocksResponse,
   DashboardMetrics,
+  DatumStatus,
   EarningsResponse,
   HealthStatus,
   Notification,
@@ -189,6 +190,11 @@ export const fetchTimezones = () =>
 
 // Health
 export const fetchHealth = () => get<HealthStatus>('/health');
+
+// DATUM gateway status — direct probe of the local DATUM gateway, with
+// the lagging pool_fees_percentage signal folded in.  See backend
+// app/routers/datum.py for the state machine.
+export const fetchDatumStatus = () => get<DatumStatus>('/datum/status');
 
 // Exchange rates
 export const fetchExchangeRates = () =>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -138,18 +138,37 @@ export const Dashboard: React.FC = () => {
       .catch(() => {});
   }, [chartHydrated, hydrateChart]);
 
-  // Fetch /health once to find out whether DATUM_GATEWAY_URL is set.
+  // Fetch /health to find out whether DATUM_GATEWAY_URL is set.
   // If it isn't, we don't poll /api/datum/status at all — the legacy
   // fee-only badge is enough for users who never configured a probe.
+  //
+  // Retry with exponential backoff if the initial request fails: a
+  // single fetch failure (transient network blip, startup race against
+  // the backend, or a slow proxy) used to leave ``health`` null for
+  // the entire session, which permanently disabled DATUM polling.
   useEffect(() => {
     let cancelled = false;
-    fetchHealth()
-      .then((h) => {
-        if (!cancelled) setHealth(h);
-      })
-      .catch(() => {});
+    let timeoutId: number | undefined;
+    const MAX_ATTEMPTS = 4; // ~ 0s, 500ms, 1.5s, 3.5s → ≊5.5s total
+
+    const attempt = (n: number) => {
+      fetchHealth()
+        .then((h) => {
+          if (!cancelled) setHealth(h);
+        })
+        .catch(() => {
+          if (cancelled) return;
+          if (n + 1 >= MAX_ATTEMPTS) return; // give up silently
+          const delay = 500 * Math.pow(2, n);
+          timeoutId = window.setTimeout(() => attempt(n + 1), delay);
+        });
+    };
+
+    attempt(0);
+
     return () => {
       cancelled = true;
+      if (timeoutId !== undefined) window.clearTimeout(timeoutId);
     };
   }, []);
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
-import React, { Suspense, lazy, useEffect, useRef } from 'react';
-import { fetchMetricHistory } from '../api/client';
+import React, { Suspense, lazy, useEffect, useRef, useState } from 'react';
+import { fetchDatumStatus, fetchHealth, fetchMetricHistory } from '../api/client';
+import type { DatumStatus, HealthStatus as HealthStatusType } from '../types';
 import { useAppStore } from '../stores/store';
 import { MetricCard } from '../components/MetricCard';
 import { PayoutSummary } from '../components/PayoutSummary';
@@ -15,9 +16,100 @@ const HashrateChart = lazy(() =>
   import('../components/HashrateChart').then((module) => ({ default: module.HashrateChart })),
 );
 
-// DATUM Gateway: pool_fees between 0.9% and 1.3% = connected via DATUM protocol
-function isDatumConnected(poolFeesPct: number): boolean {
+// Legacy fee-only DATUM signal.  We keep this as a fallback so users
+// who never configure a DATUM_GATEWAY_URL still get the old badge
+// behaviour — no regression.
+//
+// IMPORTANT: this signal LAGS reality.  pool_fees_percentage is an
+// average of historical work as reported by Ocean's stats page, so a
+// user who just enabled DATUM may not see their fee % land in the
+// 0.9%-1.3% band for hours or days.  During that window the badge
+// will say OFFLINE even though DATUM is fully operational.  This is
+// the bug that motivated the live /api/datum/status endpoint — see
+// backend/app/routers/datum.py.
+//
+// Keep these bounds in sync with DATUM_FEE_BAND_LOW/HIGH in datum.py.
+function isDatumFeeInBand(poolFeesPct: number): boolean {
   return poolFeesPct >= 0.9 && poolFeesPct <= 1.3;
+}
+
+// Poll the live DATUM probe at the same rough cadence as the metrics
+// refresh so the badge stays current without piling on requests.
+const DATUM_POLL_MS = 30_000;
+
+type DatumBadgeState = {
+  label: string;
+  className: 'badge-online' | 'badge-offline' | 'badge-warning';
+  dotColor: string;
+  glow: boolean;
+  tooltip: string;
+};
+
+function deriveDatumBadge(
+  health: HealthStatusType | null,
+  datum: DatumStatus | null,
+  poolFeesPct: number,
+): DatumBadgeState {
+  // 1) Live probe is configured — trust it as the primary signal and
+  //    use the fee-band as the secondary signal that nuances the label.
+  if (health?.datum_gateway_configured && datum) {
+    if (datum.status === 'connected') {
+      return {
+        label: 'DATUM CONNECTED',
+        className: 'badge-online',
+        dotColor: 'var(--color-success)',
+        glow: true,
+        tooltip: datum.explanation,
+      };
+    }
+    if (datum.status === 'transitioning') {
+      // Headline UX fix for the bug report: gateway is up, fees just
+      // haven't caught up yet.  Show a distinct "warming up" state so
+      // the user knows it's expected.
+      return {
+        label: datum.probe_reachable ? 'DATUM ACTIVE (fees settling)' : 'DATUM FEES ONLY',
+        className: 'badge-warning',
+        dotColor: 'var(--color-warning, #f0a020)',
+        glow: true,
+        tooltip: datum.explanation,
+      };
+    }
+    if (datum.status === 'offline') {
+      return {
+        label: 'DATUM OFFLINE',
+        className: 'badge-offline',
+        dotColor: 'var(--color-error)',
+        glow: false,
+        tooltip: datum.explanation,
+      };
+    }
+    // 'unknown' — the probe couldn't say one way or the other.  Fall
+    // through to the legacy fee check so we still show *something*.
+  }
+
+  // 2) No live probe configured (or probe returned 'unknown') —
+  //    legacy fee-only behaviour.  Note the tooltip nudges the user
+  //    toward configuring the probe if their fees aren't in band.
+  const feeBand = isDatumFeeInBand(poolFeesPct);
+  if (feeBand) {
+    return {
+      label: 'DATUM CONNECTED',
+      className: 'badge-online',
+      dotColor: 'var(--color-success)',
+      glow: true,
+      tooltip:
+        'Pool fees in the DATUM range (0.9%–1.3%). For a real-time status, set DATUM_GATEWAY_URL.',
+    };
+  }
+  return {
+    label: 'DATUM OFFLINE',
+    className: 'badge-offline',
+    dotColor: 'var(--color-error)',
+    glow: false,
+    tooltip:
+      'Pool fees are outside the DATUM range. If you just enabled DATUM, this can take hours\u2014 ' +
+      'Ocean averages over historical work. Set DATUM_GATEWAY_URL to see a live status.',
+  };
 }
 
 export const Dashboard: React.FC = () => {
@@ -31,6 +123,8 @@ export const Dashboard: React.FC = () => {
   const hydrateChart = useAppStore((s) => s.hydrateChart);
   const { annotations: blockAnnotations } = useBlockAnnotations();
   const hydrationAttempted = useRef(false);
+  const [health, setHealth] = useState<HealthStatusType | null>(null);
+  const [datum, setDatum] = useState<DatumStatus | null>(null);
 
   // Hydrate chart from server history on first load
   useEffect(() => {
@@ -43,6 +137,45 @@ export const Dashboard: React.FC = () => {
       })
       .catch(() => {});
   }, [chartHydrated, hydrateChart]);
+
+  // Fetch /health once to find out whether DATUM_GATEWAY_URL is set.
+  // If it isn't, we don't poll /api/datum/status at all — the legacy
+  // fee-only badge is enough for users who never configured a probe.
+  useEffect(() => {
+    let cancelled = false;
+    fetchHealth()
+      .then((h) => {
+        if (!cancelled) setHealth(h);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Poll /api/datum/status whenever a gateway URL is configured.  The
+  // backend caches the underlying probe for ~15s, so this is cheap.
+  useEffect(() => {
+    if (!health?.datum_gateway_configured) return;
+    let cancelled = false;
+
+    const tick = () => {
+      fetchDatumStatus()
+        .then((s) => {
+          if (!cancelled) setDatum(s);
+        })
+        .catch(() => {
+          // Swallow — next tick will retry.  We don't want a probe blip
+          // to take down the dashboard.
+        });
+    };
+    tick();
+    const id = window.setInterval(tick, DATUM_POLL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [health?.datum_gateway_configured]);
 
   useEffect(() => {
     if (!metrics) return;
@@ -65,7 +198,7 @@ export const Dashboard: React.FC = () => {
     );
   }
 
-  const datumActive = isDatumConnected(metrics.pool_fees_percentage);
+  const datumBadge = deriveDatumBadge(health, datum, metrics.pool_fees_percentage);
   const hr60 = autoScaleHashrate(metrics.hashrate_60sec, metrics.hashrate_60sec_unit);
   const hr10 = autoScaleHashrate(metrics.hashrate_10min, metrics.hashrate_10min_unit);
   const hr3 = autoScaleHashrate(metrics.hashrate_3hr, metrics.hashrate_3hr_unit);
@@ -78,24 +211,27 @@ export const Dashboard: React.FC = () => {
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '8px' }}>
         <h1 style={{ fontSize: '32px', letterSpacing: '4px' }}>MINING DASHBOARD</h1>
         <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-          {/* DATUM Gateway badge */}
+          {/* DATUM Gateway badge — derived from the live probe when a
+              gateway URL is configured, otherwise falls back to the
+              legacy pool_fees_percentage band check. */}
           <span
-            className={`badge ${datumActive ? 'badge-online' : 'badge-offline'}`}
+            className={`badge ${datumBadge.className}`}
             style={{ fontSize: '12px', padding: '4px 12px' }}
+            title={datumBadge.tooltip}
           >
             <span
               style={{
                 width: '6px',
                 height: '6px',
                 borderRadius: '50%',
-                background: datumActive ? 'var(--color-success)' : 'var(--color-error)',
+                background: datumBadge.dotColor,
                 display: 'inline-block',
-                boxShadow: datumActive ? '0 0 6px var(--color-success)' : 'none',
-                animation: datumActive ? 'pulse-glow 2s infinite' : 'none',
+                boxShadow: datumBadge.glow ? `0 0 6px ${datumBadge.dotColor}` : 'none',
+                animation: datumBadge.glow ? 'pulse-glow 2s infinite' : 'none',
                 marginRight: '6px',
               }}
             />
-            DATUM {datumActive ? 'CONNECTED' : 'OFFLINE'}
+            {datumBadge.label}
           </span>
           {metrics.low_hashrate_mode && (
             <span

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -141,6 +141,10 @@ export interface AppConfig {
   timezone: string;
   network_fee: number;
   extended_history: boolean;
+  /** Optional URL of a local DATUM Gateway (e.g. http://datum_datum_1:21000
+   *  on UmbrelOS).  Empty string disables the live probe and falls back
+   *  to the legacy pool_fees-only DATUM badge. */
+  datum_gateway_url?: string;
 }
 
 export type Theme = 'deepsea' | 'bitcoin' | 'matrix';
@@ -158,4 +162,27 @@ export interface HealthStatus {
   last_refresh?: number;
   uptime_seconds: number;
   server_timestamp?: number;
+  /** True when a DATUM gateway URL is set (env or config).  The
+   *  Dashboard uses this to decide whether to poll /api/datum/status. */
+  datum_gateway_configured?: boolean;
+}
+
+/** Live DATUM Gateway reachability + lagging-fee state.
+ *  Returned by GET /api/datum/status. */
+export type DatumStatusLabel = 'connected' | 'transitioning' | 'offline' | 'unknown';
+
+export interface DatumStatus {
+  status: DatumStatusLabel;
+  probe_reachable: boolean;
+  probe_method: 'umbrel-api' | 'stratum-tcp' | 'none';
+  gateway_url?: string | null;
+  connections?: number | null;
+  hashrate_ths?: number | null;
+  pool_fees_percentage: number;
+  fees_in_datum_band: boolean;
+  fee_band_low: number;
+  fee_band_high: number;
+  explanation: string;
+  last_check: number;
+  probe_error?: string | null;
 }

--- a/umbrel/docker-compose.yml
+++ b/umbrel/docker-compose.yml
@@ -34,6 +34,11 @@ services:
       - DB_PATH=/data/deepsea.db
       - CONFIG_PATH=/config/config.json
       - REDIS_URL=redis://redis:6379/0
+      # Live DATUM Gateway probe — point at the Umbrel DATUM app's API
+      # listener so the dashboard can render a real-time DATUM badge
+      # instead of relying on the lagging pool_fees_percentage signal.
+      # Empty / unset disables the probe and falls back to fee-only.
+      - DATUM_GATEWAY_URL=${DATUM_GATEWAY_URL:-http://datum_datum_1:21000}
     security_opt:
       - no-new-privileges:true
     healthcheck:

--- a/umbrel/docker-compose.yml
+++ b/umbrel/docker-compose.yml
@@ -37,8 +37,9 @@ services:
       # Live DATUM Gateway probe — point at the Umbrel DATUM app's API
       # listener so the dashboard can render a real-time DATUM badge
       # instead of relying on the lagging pool_fees_percentage signal.
-      # Empty / unset disables the probe and falls back to fee-only.
-      - DATUM_GATEWAY_URL=${DATUM_GATEWAY_URL:-http://datum_datum_1:21000}
+      # Only truly unset uses the default; pass DATUM_GATEWAY_URL=""
+      # (explicit empty) to disable the probe and fall back to fee-only.
+      - DATUM_GATEWAY_URL=${DATUM_GATEWAY_URL-http://datum_datum_1:21000}
     security_opt:
       - no-new-privileges:true
     healthcheck:


### PR DESCRIPTION
## Summary

Adds a **live DATUM Gateway probe** so the dashboard's DATUM badge reflects current reality instead of a lagging average. Fixes the common "I just enabled DATUM but the dashboard says OFFLINE" problem.

## Root cause

The current badge is derived purely from `pool_fees_percentage`:

```ts
function isDatumConnected(poolFeesPct: number): boolean {
  return poolFeesPct >= 0.9 && poolFeesPct <= 1.3;
}
```

That value is sourced from Ocean's stats page, which reports a **running average of historical work**. After a user turns on DATUM, their fee % drifts toward the 0.9–1.3% band over **hours or days** as new DATUM shares accumulate against the historical non-DATUM baseline. During that transition window the badge shows OFFLINE even though the gateway is up, connected to a node, and submitting templates.

So `pool_fees_percentage` is a **lagging indicator of past mining**, not a current connection state.

## Fix

Keep the lagging fee signal as a *secondary* input and add a *primary* live signal: a **direct probe of the DATUM Gateway**.

Two probe strategies, tried in order:

1. **`GET <base>/umbrel-api`** — DATUM's compiled-in JSON widget endpoint (present in any build with `DATUM_API_FOR_UMBREL`, which is what the official Umbrel app image uses). Returns worker count and a live hashrate, so we get rich info beyond a yes/no.
2. **TCP-connect on the stratum port** (default `23334`) — covers vanilla builds without the HTTP API.

Probe is cached for 15s, uses a 2s timeout, single-flighted, and never raises — failures degrade to a clean `offline` result.

### State machine

| Probe       | Fees in 0.9–1.3% | Badge                                | Reasoning                              |
|-------------|------------------|--------------------------------------|----------------------------------------|
| reachable   | yes              | `DATUM CONNECTED` (green)            | Steady state                           |
| reachable   | no               | **`DATUM ACTIVE (fees settling)`** (amber) | **The transition window — the bug**    |
| unreachable | yes              | `DATUM FEES ONLY` (amber)            | Historical DATUM, gateway may be down  |
| unreachable | no               | `DATUM OFFLINE` (red)                | Genuine offline                        |

Each state ships with an `explanation` string that's rendered into the badge tooltip so the user can *understand* why the badge looks the way it does — that transparency is the whole point.

## What's in this PR

**Backend**
- `services/datum_gateway_client.py` — probe + cache + result dataclass (no raises, single-flight lock)
- `routers/datum.py` — `GET /api/datum/status` with the 4-state machine + verbose `explanation`
- `config.datum_gateway_url` field + `DATUM_GATEWAY_URL` env override (env wins)
- `HealthStatus.datum_gateway_configured` so the frontend can skip polling when not set

**Frontend**
- `fetchDatumStatus()` helper + `DatumStatus` type
- Dashboard polls `/health` once, then `/api/datum/status` every 30 s **only when a gateway URL is configured** — zero new requests for users who never set one up
- Badge now reads from probe + fees with a tooltip explaining the state

**Tests** — 21 new pytest cases:
- Hashrate-unit parsing (`H/s` → `EH/s` → TH/s normalisation)
- `umbrel-api` happy path, 0 workers, HTTP error, connect error, invalid JSON
- Stratum-tcp success, refused, fallback when umbrel-api fails
- Env vs config precedence, cache behaviour (no extra probes within TTL)
- All four endpoint state-machine branches + `/health` flag

**Docs**
- `README.md` troubleshooting section explaining the lagging-fee root cause and how to point the dashboard at the gateway
- `CONFIG.md` reference for `datum_gateway_url`
- `config.json.example` field
- `umbrel/docker-compose.yml` ships `DATUM_GATEWAY_URL=http://datum_datum_1:21000` by default (overridable), so Umbrel installs get the right behaviour out of the box

## No regression

If `DATUM_GATEWAY_URL` is not set (env or config), the dashboard:
- Skips polling `/api/datum/status` entirely
- Falls back to the **legacy fee-only badge** with identical wording
- Adds a tooltip that points users at the setting if they want a real-time signal

## Verification

```
backend/ : 91 pytest passed, ruff clean
frontend/: 42 vitest passed, eslint clean, vite build ok
```

## Notes

- The DATUM gateway repo's example config defaults the API listen port to `7152` for stock builds. Umbrel's deployment binds the API to `21000` and exposes the container under hostname `datum_datum_1`, which is why the umbrel-compose env var is pre-populated.
- Start9 packaging is left alone here — it has its own setConfig flow, so adding the field there is best done in a separate Start9-focused PR.
- The umbrel-api JSON endpoint is documented by behaviour from the upstream `OCEAN-xyz/datum_gateway` source (`datum_api_umbrel_widget` in `src/datum_api.c`). The parser handles the documented shape and degrades gracefully on schema drift.
